### PR TITLE
Prevent issuing certificate twice with Vault Enterprise performance standbys

### DIFF
--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -6,13 +6,15 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/pkg/certificate"
-	"github.com/hashicorp/vault/logical"
-	"github.com/hashicorp/vault/logical/framework"
 	"log"
 	"net"
 	"strings"
 	"time"
+
+	"github.com/Venafi/vcert/pkg/certificate"
+	"github.com/hashicorp/vault/helper/consts"
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
 )
 
 func pathVenafiCertEnroll(b *backend) *framework.Path {
@@ -101,6 +103,13 @@ func (b *backend) pathVenafiSign(ctx context.Context, req *logical.Request, data
 
 func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request, data *framework.FieldData, role *roleEntry, signCSR bool) (
 	*logical.Response, error) {
+
+	// When utilizing performance standbys in Vault Enterprise, this forces the call to be redirected to the primary since
+	// a storage call is made after the API calls to issue the certificate.  This prevents the certificate from being
+	// issued twice in this scenario.
+	if (role.StoreByCN || role.StoreBySerial) && b.System().ReplicationState().HasState(consts.ReplicationPerformanceStandby) {
+		return nil, logical.ErrReadOnly
+	}
 
 	log.Printf("Getting the role\n")
 	roleName := data.Get("role").(string)


### PR DESCRIPTION
When utilizing [performance standby](https://www.vaultproject.io/docs/enterprise/performance-standby/index.html) nodes in Vault Enterprise any storage operations have to happen on the primary or they will be forwarded to the primary and rerun.  This fixes an issue when a requests hits a performance standby and the certificate is issued twice.  

Since this plugin can be used by both Vault OSS and Enterprise users, this will allow the plugin to work in both scenarios.  