### PR TITLE
Ven 58645 fix part2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ VERSION=$(RELEASE_VERSION)
 endif
 endif
 
-###Demo scripts parameteres
+###Demo scripts parameters
 VAULT_VERSION := $(shell vault --version|awk '{print $$2}')
 VAULT_CONT := $$(docker-compose ps |grep Up|grep vault_1|awk '{print $$1}')
 DOCKER_CMD := docker exec -it $(VAULT_CONT)
@@ -34,9 +34,16 @@ VAULT_CMD := $(DOCKER_CMD) vault
 CT_CMD := consul-template
 
 MOUNT := venafi-pki
+FAKE_VENAFI := fakeVenafi
+TPP_VENAFI := tppVenafi
+CLOUD_VENAFI := cloudVenafi
+TOKEN_VENAFI := tppTokenVenafi
+
 FAKE_ROLE := fake
 TPP_ROLE := tpp
 CLOUD_ROLE := cloud
+TOKEN_ROLE := tppToken
+
 ROLE_OPTIONS := generate_lease=true store_by="cn" store_pkey="true" ttl=1h max_ttl=1h
 
 SHA256 := $$(shasum -a 256 "$(PLUGIN_PATH)" | cut -d' ' -f1)
@@ -114,8 +121,8 @@ test_go:
 		)
 
 test_e2e:
-	sed -i "s#image:.*$(IMAGE_NAME).*#image: $(DOCKER_IMAGE):$(BUILD_TAG)#" docker-compose.yaml
-	cd plugin/pki/e2e && ginkgo -v
+	sed -i -e "s#image:.*$(IMAGE_NAME).*#image: $(DOCKER_IMAGE):$(BUILD_TAG)#" docker-compose.yaml
+	cd plugin/pki/e2e && ~/go/bin/ginkgo -v
 
 test_tpp:
 	go test -run  ^TestTPPIntegration$ -v github.com/Venafi/vault-pki-backend-venafi/plugin/pki
@@ -125,6 +132,9 @@ test_cloud:
 
 test_fake:
 	go test -run  ^TestFake -v github.com/Venafi/vault-pki-backend-venafi/plugin/pki
+
+test_token:
+	go test -run ^TestTokenIntegration$ -v github.com/Venafi/vault-pki-backend-venafi/plugin/pki
 
 push: build build_docker test_e2e
 	docker push $(DOCKER_IMAGE):$(BUILD_TAG)
@@ -200,11 +210,12 @@ mount_prod:
 	$(VAULT_CMD) secrets disable $(MOUNT) || echo "Secrets already disabled"
 	$(VAULT_CMD) secrets enable -path=$(MOUNT) -plugin-name=$(PLUGIN_NAME) plugin
 
-
 #Fake role tasks
 fake_config_write:
-	vault write $(MOUNT)/roles/$(FAKE_ROLE) fakemode="true" $(ROLE_OPTIONS)
+	vault write $(MOUNT)/venafi/$(FAKE_VENAFI) fakemode="true"
+	vault write $(MOUNT)/roles/$(FAKE_ROLE) venafi_secret=$(FAKE_VENAFI) $(ROLE_OPTIONS)
 fake_config_read:
+	vault read $(MOUNT)/venafi/$(FAKE_VENAFI)
 	vault read $(MOUNT)/roles/$(FAKE_ROLE)
 
 fake_cert_write:
@@ -223,11 +234,12 @@ fake_cert_read_pkey:
 
 fake: fake_config_write fake_cert_write fake_cert_read_certificate fake_cert_read_pkey
 
-
 #Cloud role tasks
 cloud_config_write:
-	vault write $(MOUNT)/roles/$(CLOUD_ROLE) cloud_url=$(CLOUD_URL) zone="$(CLOUD_ZONE)" apikey=$(CLOUD_APIKEY) $(ROLE_OPTIONS)
+	vault write $(MOUNT)/venafi/$(CLOUD_VENAFI) cloud_url=$(CLOUD_URL) zone="$(CLOUD_ZONE)" apikey=$(CLOUD_APIKEY)
+	vault write $(MOUNT)/roles/$(CLOUD_ROLE) venafi_secret=$(CLOUD_VENAFI) $(ROLE_OPTIONS)
 cloud_config_read:
+	vault read $(MOUNT)/venafi/$(CLOUD_VENAFI)
 	vault read $(MOUNT)/roles/$(CLOUD_ROLE)
 
 cloud_cert_write:
@@ -246,10 +258,13 @@ cloud_cert_read_pkey:
 
 cloud: cloud_config_write cloud_cert_write cloud_cert_read_certificate cloud_cert_read_pkey
 
+
 #TPP role tasks
 tpp_config_write:
-	vault write $(MOUNT)/roles/$(TPP_ROLE) tpp_url=$(TPP_URL) tpp_user=$(TPP_USER) tpp_password=$(TPP_PASSWORD) zone="$(TPP_ZONE)" trust_bundle_file=$(TRUST_BUNDLE) $(ROLE_OPTIONS)
+	vault write $(MOUNT)/venafi/$(TPP_VENAFI) tpp_url=$(TPP_URL) tpp_user=$(TPP_USER) tpp_password=$(TPP_PASSWORD) zone="$(TPP_ZONE)" trust_bundle_file=$(TRUST_BUNDLE)
+	vault write $(MOUNT)/roles/$(TPP_ROLE) venafi_secret=$(TPP_VENAFI) $(ROLE_OPTIONS)
 tpp_config_read:
+	vault read $(MOUNT)/venafi/$(TPP_VENAFI)
 	vault read $(MOUNT)/roles/$(TPP_ROLE)
 
 tpp_cert_write:
@@ -267,6 +282,29 @@ tpp_cert_read_pkey:
 
 
 tpp: tpp_config_write tpp_cert_write tpp_cert_read_certificate tpp_cert_read_pkey
+
+
+#TPP Token tasks
+token_config_write:
+	vault write $(MOUNT)/venafi/$(TOKEN_VENAFI) url=$(TPP_TOKEN_URL) access_token=$(TPP_ACCESS_TOKEN) zone="$(TPP_ZONE)" trust_bundle_file=$(TRUST_BUNDLE)
+	vault write $(MOUNT)/roles/$(TOKEN_ROLE) venafi_secret=$(TOKEN_VENAFI) $(ROLE_OPTIONS)
+token_config_read:
+	vault read $(MOUNT)/venafi/$(TOKEN_VENAFI)
+	vault read $(MOUNT)/roles/$(TOKEN_ROLE)
+token_cert_write:
+	$(eval RANDOM_SITE := $(shell echo $(RANDOM_SITE_EXP)))
+	@echo "Issuing tpp-$(RANDOM_SITE).$(TPP_DOMAIN)"
+	vault write $(MOUNT)/issue/$(TOKEN_ROLE) common_name="tppToken-$(RANDOM_SITE).$(TPP_DOMAIN)" alt_names="alt-$(RANDOM_SITE).$(TPP_DOMAIN),alt2-$(RANDOM_SITE).$(TPP_DOMAIN)"
+token_cert_read_certificate:
+	vault read -field=certificate $(MOUNT)/cert/tppToken-$(RANDOM_SITE).$(TPP_DOMAIN) > $(CERT_TMP_FILE)
+	$(CHECK_CERT_CMD) $(CERT_TMP_FILE)
+token_cert_read_pkey:
+	vault read -field=private_key $(MOUNT)/cert/tppToken-$(RANDOM_SITE).$(TPP_DOMAIN)|tee /tmp/privateKey.key
+	@echo "\nChecking modulus for certificate and key:\n"
+	@openssl pkey -in /tmp/privateKey.key -pubout -outform pem| sha256sum
+	@openssl x509 -in $(CERT_TMP_FILE) -pubkey -noout -outform pem | sha256sum
+
+tpp_token: token_config_write token_cert_write token_cert_read_certificate token_cert_read_pkey
 
 
 #Consul template tasks

--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,8 @@ test_go:
 		)
 
 test_e2e:
-	sed -i -e "s#image:.*$(IMAGE_NAME).*#image: $(DOCKER_IMAGE):$(BUILD_TAG)#" docker-compose.yaml
-	cd plugin/pki/e2e && ~/go/bin/ginkgo -v
+	sed -i "s#image:.*$(IMAGE_NAME).*#image: $(DOCKER_IMAGE):$(BUILD_TAG)#" docker-compose.yaml
+	cd plugin/pki/e2e && ginkgo -v
 
 test_tpp:
 	go test -run  ^TestTPPIntegration$ -v github.com/Venafi/vault-pki-backend-venafi/plugin/pki

--- a/plugin/pki/backend.go
+++ b/plugin/pki/backend.go
@@ -31,6 +31,8 @@ func Backend(conf *logical.BackendConfig) *backend {
 		Paths: []*framework.Path{
 			pathListRoles(&b),
 			pathRoles(&b),
+			pathCredentialsList(&b),
+			pathCredentials(&b),
 			pathVenafiCertEnroll(&b),
 			pathVenafiCertSign(&b),
 			pathVenafiCertRead(&b),

--- a/plugin/pki/backend_test.go
+++ b/plugin/pki/backend_test.go
@@ -9,13 +9,37 @@ func TestFakeRolesConfigurations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Run("create wrong role", integrationTestEnv.CreateMixedRole)
-	t.Run("delete role", integrationTestEnv.DeleteRole)
-	t.Run("tpp create role", integrationTestEnv.TPPCreateRole)
-	t.Run("tpp read role", integrationTestEnv.TPPReadRole)
-	t.Run("delete role", integrationTestEnv.DeleteRole)
-	t.Run("cloud create role", integrationTestEnv.CloudCreateRole)
-	t.Run("cloud read role", integrationTestEnv.CloudReadRole)
+
+	t.Run("create role with no venafi secret", integrationTestEnv.CreateRoleEmptyVenafi)
+
+}
+
+func TestFakeVenafiSecretsConfigurations(t *testing.T) {
+	integrationTestEnv, err := newIntegrationTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("create wrong venafi secret (TPP/Cloud)", integrationTestEnv.CreateVenafiMixedTppAndCloud)
+	t.Run("delete venafi secret", integrationTestEnv.DeleteVenafi)
+
+	t.Run("create wrong venafi secret (TPP/Token)", integrationTestEnv.CreateVenafiMixedTppAndToken)
+	t.Run("delete venafi secret", integrationTestEnv.DeleteVenafi)
+
+	t.Run("create wrong venafi secret (Token/Cloud)", integrationTestEnv.CreateVenafiMixedTokenAndCloud)
+	t.Run("delete venafi secret", integrationTestEnv.DeleteVenafi)
+
+	t.Run("create venafi secret TPP", integrationTestEnv.CreateVenafiTPP)
+	t.Run("read venafi secret TPP", integrationTestEnv.ReadVenafiTPP)
+	t.Run("delete venafi secret", integrationTestEnv.DeleteVenafi)
+
+	t.Run("create venafi secret Cloud", integrationTestEnv.CreateVenafiCloud)
+	t.Run("read venafi secret Cloud", integrationTestEnv.ReadVenafiCloud)
+	t.Run("delete venafi secret", integrationTestEnv.DeleteVenafi)
+
+	t.Run("create venafi secret TPP Token", integrationTestEnv.CreateVenafiToken)
+	t.Run("read venafi secret TPP Token", integrationTestEnv.ReadVenafiToken)
+	t.Run("delete venafi secret", integrationTestEnv.DeleteVenafi)
 }
 
 //Testing all endpoints with fake vcert CA
@@ -25,6 +49,9 @@ func TestFakeEndpoints(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	t.Run("fake create venafi secret", integrationTestEnv.FakeCreateVenafi)
+	t.Run("fake list venafi secrets", integrationTestEnv.FakeListVenafi)
+	t.Run("fake read venafi secrets", integrationTestEnv.FakeReadVenafi)
 	t.Run("fake create role", integrationTestEnv.FakeCreateRole)
 	t.Run("fake list roles", integrationTestEnv.FakeListRole)
 	t.Run("fake read roles", integrationTestEnv.FakeReadRole)
@@ -44,40 +71,53 @@ func TestFakeStoreByOptions(t *testing.T) {
 	}
 
 	//test store_by_serial deprecated option
+	t.Run("create venafi secret", integrationTestEnv.FakeCreateVenafi)
 	t.Run("create role deprecated store_by_serial", integrationTestEnv.FakeCreateRoleDeprecatedStoreBySerial)
 	t.Run("issue", integrationTestEnv.FakeIssueCertificateAndSaveSerial)
 	t.Run("read certificate by serial", integrationTestEnv.FakeReadCertificateBySerial)
 	t.Run("delete role", integrationTestEnv.DeleteRole)
+	t.Run("delete venafi", integrationTestEnv.DeleteVenafi)
 
 	//test store_by_cn deprecated option
+	t.Run("create venafi secret", integrationTestEnv.FakeCreateVenafi)
 	t.Run("create role deprecated store_by_cn", integrationTestEnv.FakeCreateRoleDeprecatedStoreByCN)
 	t.Run("issue", integrationTestEnv.FakeIssueCertificateAndSaveSerial)
 	t.Run("read certificate by cn", integrationTestEnv.FakeReadCertificateByCN)
 	t.Run("delete role", integrationTestEnv.DeleteRole)
+	t.Run("delete venafi", integrationTestEnv.DeleteVenafi)
 
 	//test store_by cn
+	t.Run("create venafi secret", integrationTestEnv.FakeCreateVenafi)
 	t.Run("create role store_by cn", integrationTestEnv.FakeCreateRoleStoreByCN)
 	t.Run("issue", integrationTestEnv.FakeIssueCertificateAndSaveSerial)
 	t.Run("read certificate by cn", integrationTestEnv.FakeReadCertificateByCN)
 	t.Run("delete role", integrationTestEnv.DeleteRole)
+	t.Run("delete venafi", integrationTestEnv.DeleteVenafi)
 
 	//test store_by default
+	t.Run("create venafi secret", integrationTestEnv.FakeCreateVenafi)
 	t.Run("create role store_by serial", integrationTestEnv.FakeCreateRoleStoreBySerial)
 	t.Run("issue", integrationTestEnv.FakeIssueCertificateAndSaveSerial)
 	t.Run("read certificate by serial", integrationTestEnv.FakeReadCertificateBySerial)
 	t.Run("delete role", integrationTestEnv.DeleteRole)
+	t.Run("delete venafi", integrationTestEnv.DeleteVenafi)
 
 	//test no_store
+	t.Run("create venafi secret", integrationTestEnv.FakeCreateVenafi)
 	t.Run("create role no_store true", integrationTestEnv.FakeCreateRoleNoStore)
 	t.Run("issue", integrationTestEnv.FakeIssueCertificateAndSaveSerial)
 	t.Run("check that there is no certificate", integrationTestEnv.FakeCheckThatThereIsNoCertificate)
 	t.Run("delete role", integrationTestEnv.DeleteRole)
+	t.Run("delete venafi", integrationTestEnv.DeleteVenafi)
 
 	//test store_pkey false
+	t.Run("create venafi secret", integrationTestEnv.FakeCreateVenafi)
 	t.Run("create role store_pkey false", integrationTestEnv.FakeCreateRoleNoStorePKey)
 	t.Run("issue", integrationTestEnv.FakeIssueCertificateAndSaveSerial)
 	t.Run("check that there is no private key", integrationTestEnv.FakeCheckThatThereIsNoPKey)
 	t.Run("delete role", integrationTestEnv.DeleteRole)
+	t.Run("delete venafi", integrationTestEnv.DeleteVenafi)
+
 }
 
 //Testing Venafi Platform integration
@@ -107,4 +147,20 @@ func TestCloudIntegration(t *testing.T) {
 	t.Run("Cloud restricted enroll", integrationTestEnv.CloudIntegrationIssueCertificateRestricted)
 	t.Run("Cloud issue certificate with password", integrationTestEnv.CloudIntegrationIssueCertificateWithPassword)
 	t.Run("Cloud sign certificate", integrationTestEnv.CloudIntegrationSignCertificate)
+
+}
+
+//Testing Venafi TPP Token integration
+func TestTokenIntegration(t *testing.T) {
+
+	integrationTestEnv, err := newIntegrationTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("TPP Token base enroll", integrationTestEnv.TokenIntegrationIssueCertificate)
+	t.Run("TPP Token base enroll with password", integrationTestEnv.TokenIntegrationIssueCertificateWithPassword)
+	t.Run("TPP Token restricted enroll", integrationTestEnv.TokenIntegrationIssueCertificateRestricted)
+	t.Run("TPP Token sign certificate", integrationTestEnv.TokenIntegrationSignCertificate)
+
 }

--- a/plugin/pki/env_test.go
+++ b/plugin/pki/env_test.go
@@ -26,6 +26,7 @@ type testEnv struct {
 	TestRandString    string
 	RoleName          string
 	CertificateSerial string
+	VenafiSecretName  string
 }
 
 type venafiConfigString string
@@ -49,10 +50,13 @@ type testData struct {
 const (
 	venafiConfigTPP                         venafiConfigString = "TPP"
 	venafiConfigTPPPredefined               venafiConfigString = "TPPPredefined"
-	venafiConfigCloudPredefined             venafiConfigString = "CloudPredefined"
 	venafiConfigTPPRestricted               venafiConfigString = "TPPRestricted"
 	venafiConfigCloud                       venafiConfigString = "Cloud"
+	venafiConfigCloudPredefined             venafiConfigString = "CloudPredefined"
 	venafiConfigCloudRestricted             venafiConfigString = "CloudRestricted"
+	venafiConfigToken                       venafiConfigString = "TppToken"
+	venafiConfigTokenPredefined             venafiConfigString = "TppTokenPredefined"
+	venafiConfigTokenRestricted             venafiConfigString = "TppTokenRestricted"
 	venafiConfigFake                        venafiConfigString = "Fake"
 	venafiConfigFakeDeprecatedStoreByCN     venafiConfigString = "FakeDeprecatedStoreByCN"
 	venafiConfigFakeDeprecatedStoreBySerial venafiConfigString = "venafiConfigFakeDeprecatedStoreBySerial"
@@ -60,11 +64,20 @@ const (
 	venafiConfigFakeStoreBySerial           venafiConfigString = "venafiConfigFakeStoreBySerial"
 	venafiConfigFakeNoStore                 venafiConfigString = "venafiConfigFakeNoStore"
 	venafiConfigFakeNoStorePKey             venafiConfigString = "venafiConfigFakeNoStorePKey"
-	venafiConfigMixed                       venafiConfigString = "Mixed"
+	venafiConfigMixedTppAndCloud            venafiConfigString = "MixedTppCloud"
+	venafiConfigMixedTppAndToken            venafiConfigString = "MixedTppToken"
+	venafiConfigMixedTokenAndCloud          venafiConfigString = "MixedTokenCloud"
+
+	venafiVenafiConfigFake venafiConfigString = "VenafiFake"
+	venafiRoleConfig       venafiConfigString = "Role"
 )
 
+var venafiTestRoleConfig = map[string]interface{}{
+	"venafi_secret": "",
+}
+
 var venafiTestTPPConfig = map[string]interface{}{
-	"tpp_url":           os.Getenv("TPP_URL"),
+	"url":               os.Getenv("TPP_URL"),
 	"tpp_user":          os.Getenv("TPP_USER"),
 	"tpp_password":      os.Getenv("TPP_PASSWORD"),
 	"zone":              os.Getenv("TPP_ZONE"),
@@ -72,7 +85,7 @@ var venafiTestTPPConfig = map[string]interface{}{
 }
 
 var venafiTestTPPConfigPredefined = map[string]interface{}{
-	"tpp_url":           "https://tpp.example.com/vedsdk",
+	"url":               "https://tpp.example.com/vedsdk",
 	"tpp_user":          "admin",
 	"tpp_password":      "strongPassword",
 	"zone":              "devops\\vcert",
@@ -80,7 +93,7 @@ var venafiTestTPPConfigPredefined = map[string]interface{}{
 }
 
 var venafiTestTPPConfigRestricted = map[string]interface{}{
-	"tpp_url":           os.Getenv("TPP_URL"),
+	"url":               os.Getenv("TPP_URL"),
 	"tpp_user":          os.Getenv("TPP_USER"),
 	"tpp_password":      os.Getenv("TPP_PASSWORD"),
 	"zone":              os.Getenv("TPP_ZONE_RESTRICTED"),
@@ -88,9 +101,9 @@ var venafiTestTPPConfigRestricted = map[string]interface{}{
 }
 
 var venafiTestCloudConfig = map[string]interface{}{
-	"cloud_url": os.Getenv("CLOUD_URL"),
-	"apikey":    os.Getenv("CLOUD_APIKEY"),
-	"zone":      os.Getenv("CLOUD_ZONE"),
+	"url":    os.Getenv("CLOUD_URL"),
+	"apikey": os.Getenv("CLOUD_APIKEY"),
+	"zone":   os.Getenv("CLOUD_ZONE"),
 }
 
 var venafiTestCloudConfigPredefined = map[string]interface{}{
@@ -99,60 +112,95 @@ var venafiTestCloudConfigPredefined = map[string]interface{}{
 }
 
 var venafiTestCloudConfigRestricted = map[string]interface{}{
-	"cloud_url": os.Getenv("CLOUD_URL"),
-	"apikey":    os.Getenv("CLOUD_APIKEY"),
-	"zone":      os.Getenv("CLOUD_ZONE_RESTRICTED"),
+	"url":    os.Getenv("CLOUD_URL"),
+	"apikey": os.Getenv("CLOUD_APIKEY"),
+	"zone":   os.Getenv("CLOUD_ZONE_RESTRICTED"),
+}
+
+var venafiTestTokenConfig = map[string]interface{}{
+	"url":               os.Getenv("TPP_URL"),
+	"access_token":      os.Getenv("TPP_ACCESS_TOKEN"),
+	"zone":              os.Getenv("TPP_ZONE"),
+	"trust_bundle_file": os.Getenv("TRUST_BUNDLE"),
+}
+
+var venafiTestTokenConfigPredefined = map[string]interface{}{
+	"url":               "https://tpp.example.com/vedsdk",
+	"access_token":      "admin",
+	"zone":              "devops\\vcert",
+	"trust_bundle_file": "/opt/venafi/bundle.pem",
+}
+
+var venafiTestTokenConfigRestricted = map[string]interface{}{
+	"url":               os.Getenv("TPP_URL"),
+	"access_token":      os.Getenv("TPP_ACCESS_TOKEN"),
+	"zone":              os.Getenv("TPP_ZONE_RESTRICTED"),
+	"trust_bundle_file": os.Getenv("TRUST_BUNDLE"),
 }
 
 var venafiTestFakeConfigDeprecatedStoreByCN = map[string]interface{}{
 	"generate_lease": true,
-	"fakemode":       true,
 	"store_by_cn":    true,
 	"store_pkey":     true,
 }
 
 var venafiTestFakeConfigDeprecatedStoreBySerial = map[string]interface{}{
 	"generate_lease":  true,
-	"fakemode":        true,
 	"store_by_serial": true,
 	"store_pkey":      true,
 }
 
 var venafiTestFakeConfigStoreByCN = map[string]interface{}{
 	"generate_lease": true,
-	"fakemode":       true,
 	"store_by":       "cn",
 	"store_pkey":     true,
 }
 
 var venafiTestFakeConfigStoreBySerial = map[string]interface{}{
 	"generate_lease": true,
-	"fakemode":       true,
 	"store_by":       "serial",
 	"store_pkey":     true,
 }
 
 var venafiTestFakeConfig = map[string]interface{}{
 	"generate_lease": true,
-	"fakemode":       true,
 	"store_pkey":     true,
 }
 
 var venafiTestFakeConfigNoStore = map[string]interface{}{
 	"generate_lease": true,
-	"fakemode":       true,
 	"no_store":       true,
 }
 
 var venafiTestFakeConfigNoStorePKey = map[string]interface{}{
 	"generate_lease": true,
-	"fakemode":       true,
 	"store_pkey":     false,
 }
 
-var venafiTestMixedConfig = map[string]interface{}{
-	"apikey":  "xxxxxxxxxxxxxxxx",
-	"tpp_url": "xxxxxxxxxxx",
+var venafiTestMixedTppAndCloudConfig = map[string]interface{}{
+	"url":      "xxxxxxxxxxx",
+	"apikey":   "xxxxxxxxxxxxxxxx",
+	"tpp_user": "admin",
+	"zone":     "devops\\vcert",
+}
+
+var venafiTestMixedTppAndTokenConfig = map[string]interface{}{
+	"url":          "xxxxxxxxxxx",
+	"tpp_user":     "admin",
+	"tpp_password": "weakPassword",
+	"access_token": "xxxxxxxxxx==",
+	"zone":         "devops\\vcert",
+}
+
+var venafiTestMixedTokenAndCloudConfig = map[string]interface{}{
+	"url":          "xxxxxxxxxxx",
+	"access_token": "xxxxxxxxxx==",
+	"apikey":       "xxxxxxxxxxxxxxxx",
+	"zone":         "devops\\vcert",
+}
+
+var venafiVenafiTestFakeConfig = map[string]interface{}{
+	"fakemode": true,
 }
 
 func (e *testEnv) writeRoleToBackend(t *testing.T, configString venafiConfigString) {
@@ -160,6 +208,9 @@ func (e *testEnv) writeRoleToBackend(t *testing.T, configString venafiConfigStri
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	//Adding Venafi secret reference to Role
+	roleData["venafi_secret"] = e.VenafiSecretName
 
 	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -200,8 +251,8 @@ func (e *testEnv) failToWriteRoleToBackend(t *testing.T, configString venafiConf
 
 	errText := resp.Data["error"].(string)
 
-	if errText != errorTextTPPandCloudMixedCredentials {
-		t.Fatalf("Expecting error with text %s but got %s", errorTextTPPandCloudMixedCredentials, errText)
+	if errText != errorTextVenafiSecretEmpty {
+		t.Fatalf("Expecting error with text %s but got %s", errorTextVenafiSecretEmpty, errText)
 	}
 }
 
@@ -268,6 +319,120 @@ func (e *testEnv) readRolesInBackend(t *testing.T, config map[string]interface{}
 		}
 	}
 
+}
+
+func (e *testEnv) writeVenafiToBackend(t *testing.T, configString venafiConfigString) {
+	roleData, err := makeConfig(configString)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "venafi/" + e.VenafiSecretName,
+		Storage:   e.Storage,
+		Data:      roleData,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to create venafi, %#v", resp)
+	}
+}
+
+func (e *testEnv) failToWriteVenafiToBackend(t *testing.T, configString venafiConfigString, expectedError string) {
+	roleData, err := makeConfig(configString)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "venafi/" + e.VenafiSecretName,
+		Storage:   e.Storage,
+		Data:      roleData,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp != nil && !resp.IsError() {
+		t.Fatal("Venafi secret with mixed cloud api key and tpp url should fail to write")
+	}
+
+	errText := resp.Data["error"].(string)
+
+	if errText != expectedError {
+		t.Fatalf("Expecting error with text %s but got %s", expectedError, errText)
+	}
+}
+
+func (e *testEnv) listVenafiInBackend(t *testing.T) {
+
+	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
+		Operation: logical.ListOperation,
+		Path:      "venafi",
+		Storage:   e.Storage,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to list venafi secrets, %#v", resp)
+	}
+
+	if resp.Data["keys"] == nil {
+		t.Fatalf("Expected there will be venafi secrets in the keys list")
+	}
+
+	if !sliceContains(resp.Data["keys"].([]string), e.VenafiSecretName) {
+		t.Fatalf("expected venafi secret name %s in list %s", e.VenafiSecretName, resp.Data["keys"])
+	}
+}
+
+func (e *testEnv) readVenafiInBackend(t *testing.T, config map[string]interface{}) {
+
+	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "venafi/" + e.VenafiSecretName,
+		Storage:   e.Storage,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp == nil {
+		t.Fatalf("should be on output on reading the venafi secret %s, but response is nil: %#v", e.VenafiSecretName, resp)
+	}
+
+	if resp.IsError() {
+		t.Fatalf("failed to read venafi %s, %#v", e.VenafiSecretName, resp)
+	}
+
+	sensitiveData := []string{"tpp_password", "apikey", "access_token", "refresh_token"}
+
+	for k, v := range config {
+		if sliceContains(sensitiveData, k) {
+			if resp.Data[k] != "********" {
+				t.Fatalf("Sensitive data %s should be hidden", k)
+			}
+		} else {
+			if resp.Data[k] == nil {
+				t.Fatalf("Expected there will be value in %s field", k)
+			}
+
+			if resp.Data[k] != v {
+				t.Fatalf("Expected %#v will be %#v", k, v)
+			}
+		}
+	}
 }
 
 func (e *testEnv) IssueCertificateAndSaveSerial(t *testing.T, data testData, configString venafiConfigString) {
@@ -562,18 +727,32 @@ func makeConfig(configString venafiConfigString) (roleData map[string]interface{
 		roleData = venafiTestFakeConfigNoStorePKey
 	case venafiConfigTPP:
 		roleData = venafiTestTPPConfig
+	case venafiConfigTPPPredefined:
+		roleData = venafiTestTPPConfigPredefined
 	case venafiConfigTPPRestricted:
 		roleData = venafiTestTPPConfigRestricted
 	case venafiConfigCloud:
 		roleData = venafiTestCloudConfig
-	case venafiConfigCloudRestricted:
-		roleData = venafiTestCloudConfigRestricted
 	case venafiConfigCloudPredefined:
 		roleData = venafiTestCloudConfigPredefined
-	case venafiConfigMixed:
-		roleData = venafiTestMixedConfig
-	case venafiConfigTPPPredefined:
-		roleData = venafiTestTPPConfigPredefined
+	case venafiConfigCloudRestricted:
+		roleData = venafiTestCloudConfigRestricted
+	case venafiConfigToken:
+		roleData = venafiTestTokenConfig
+	case venafiConfigTokenPredefined:
+		roleData = venafiTestTokenConfigPredefined
+	case venafiConfigTokenRestricted:
+		roleData = venafiTestTokenConfigRestricted
+	case venafiConfigMixedTppAndCloud:
+		roleData = venafiTestMixedTppAndCloudConfig
+	case venafiConfigMixedTppAndToken:
+		roleData = venafiTestMixedTppAndTokenConfig
+	case venafiConfigMixedTokenAndCloud:
+		roleData = venafiTestMixedTokenAndCloudConfig
+	case venafiVenafiConfigFake:
+		roleData = venafiVenafiTestFakeConfig
+	case venafiRoleConfig:
+		roleData = venafiTestRoleConfig
 	default:
 		return roleData, fmt.Errorf("do not have config data for config %s", configString)
 	}
@@ -587,6 +766,11 @@ func (e *testEnv) FakeCreateRole(t *testing.T) {
 	var config = venafiConfigFake
 	e.writeRoleToBackend(t, config)
 
+}
+
+func (e *testEnv) FakeCreateVenafi(t *testing.T) {
+	var config = venafiVenafiConfigFake
+	e.writeVenafiToBackend(t, config)
 }
 
 func (e *testEnv) FakeCreateRoleDeprecatedStoreByCN(t *testing.T) {
@@ -631,25 +815,83 @@ func (e *testEnv) FakeCreateRoleNoStorePKey(t *testing.T) {
 
 }
 
-func (e *testEnv) TPPCreateRole(t *testing.T) {
+func (e *testEnv) CreateVenafiTPP(t *testing.T) {
 
 	var config = venafiConfigTPPPredefined
-	e.writeRoleToBackend(t, config)
+	e.writeVenafiToBackend(t, config)
 
 }
 
-func (e *testEnv) CloudCreateRole(t *testing.T) {
+func (e *testEnv) CreateVenafiCloud(t *testing.T) {
 
 	var config = venafiConfigCloudPredefined
-	e.writeRoleToBackend(t, config)
+	e.writeVenafiToBackend(t, config)
 
 }
 
-func (e *testEnv) CreateMixedRole(t *testing.T) {
+func (e *testEnv) CreateVenafiToken(t *testing.T) {
 
-	var config = venafiConfigMixed
+	var config = venafiConfigTokenPredefined
+	e.writeVenafiToBackend(t, config)
+}
+
+func (e *testEnv) CreateVenafiMixedTppAndCloud(t *testing.T) {
+
+	var config = venafiConfigMixedTppAndCloud
+	e.failToWriteVenafiToBackend(t, config, errorTextMixedTPPAndCloud)
+
+}
+
+func (e *testEnv) CreateVenafiMixedTppAndToken(t *testing.T) {
+
+	var config = venafiConfigMixedTppAndToken
+	e.failToWriteVenafiToBackend(t, config, errorTextMixedTPPAndToken)
+
+}
+
+func (e *testEnv) CreateVenafiMixedTokenAndCloud(t *testing.T) {
+
+	var config = venafiConfigMixedTokenAndCloud
+	e.failToWriteVenafiToBackend(t, config, errorTextMixedTokenAndCloud)
+
+}
+
+func (e *testEnv) DeleteVenafi(t *testing.T) {
+
+	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
+		Operation: logical.DeleteOperation,
+		Path:      "venafi/" + e.VenafiSecretName,
+		Storage:   e.Storage,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp != nil && resp.IsError() {
+		t.Fatal(resp)
+	}
+
+	resp, err = e.Backend.HandleRequest(e.Context, &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "venafi/" + e.VenafiSecretName,
+		Storage:   e.Storage,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp != nil {
+		t.Fatalf("should be no output on reading the deleted venafi secret %s, but response is: %#v", e.VenafiSecretName, resp)
+	}
+
+}
+
+func (e *testEnv) CreateRoleEmptyVenafi(t *testing.T) {
+
+	var config = venafiRoleConfig
 	e.failToWriteRoleToBackend(t, config)
-
 }
 
 func (e *testEnv) FakeCheckThatThereIsNoCertificate(t *testing.T) {
@@ -698,7 +940,7 @@ func (e *testEnv) DeleteRole(t *testing.T) {
 	}
 
 	if resp != nil {
-		t.Fatalf("should be no output on reading the delted role %s, but response is: %#v", e.RoleName, resp)
+		t.Fatalf("should be no output on reading the deleted role %s, but response is: %#v", e.RoleName, resp)
 	}
 
 }
@@ -714,15 +956,33 @@ func (e *testEnv) FakeReadRole(t *testing.T) {
 
 }
 
-func (e *testEnv) TPPReadRole(t *testing.T) {
+func (e *testEnv) FakeListVenafi(t *testing.T) {
 
-	e.readRolesInBackend(t, venafiTestTPPConfigPredefined)
+	e.listVenafiInBackend(t)
 
 }
 
-func (e *testEnv) CloudReadRole(t *testing.T) {
+func (e *testEnv) FakeReadVenafi(t *testing.T) {
 
-	e.readRolesInBackend(t, venafiTestCloudConfigPredefined)
+	e.readVenafiInBackend(t, venafiVenafiTestFakeConfig)
+
+}
+
+func (e *testEnv) ReadVenafiTPP(t *testing.T) {
+
+	e.readVenafiInBackend(t, venafiTestTPPConfigPredefined)
+
+}
+
+func (e *testEnv) ReadVenafiCloud(t *testing.T) {
+
+	e.readVenafiInBackend(t, venafiTestCloudConfigPredefined)
+
+}
+
+func (e *testEnv) ReadVenafiToken(t *testing.T) {
+
+	e.readVenafiInBackend(t, venafiTestTokenConfigPredefined)
 
 }
 
@@ -872,6 +1132,7 @@ func (e *testEnv) TPPIntegrationIssueCertificate(t *testing.T) {
 
 	var config = venafiConfigTPP
 
+	e.writeVenafiToBackend(t, config)
 	e.writeRoleToBackend(t, config)
 	e.IssueCertificateAndSaveSerial(t, data, config)
 
@@ -890,6 +1151,7 @@ func (e *testEnv) TPPIntegrationIssueCertificateWithPassword(t *testing.T) {
 
 	var config = venafiConfigTPP
 
+	e.writeVenafiToBackend(t, config)
 	e.writeRoleToBackend(t, config)
 	e.IssueCertificateAndSaveSerial(t, data, config)
 
@@ -907,6 +1169,7 @@ func (e *testEnv) TPPIntegrationIssueCertificateRestricted(t *testing.T) {
 
 	var config = venafiConfigTPPRestricted
 
+	e.writeVenafiToBackend(t, config)
 	e.writeRoleToBackend(t, config)
 	e.IssueCertificateAndSaveSerial(t, data, config)
 
@@ -925,6 +1188,7 @@ func (e *testEnv) TPPIntegrationSignCertificate(t *testing.T) {
 
 	var config = venafiConfigTPP
 
+	e.writeVenafiToBackend(t, config)
 	e.writeRoleToBackend(t, config)
 	e.SignCertificate(t, data, config)
 
@@ -941,6 +1205,7 @@ func (e *testEnv) CloudIntegrationSignCertificate(t *testing.T) {
 
 	var config = venafiConfigCloud
 
+	e.writeVenafiToBackend(t, config)
 	e.writeRoleToBackend(t, config)
 	e.SignCertificate(t, data, config)
 
@@ -956,6 +1221,7 @@ func (e *testEnv) CloudIntegrationIssueCertificate(t *testing.T) {
 
 	var config = venafiConfigCloud
 
+	e.writeVenafiToBackend(t, config)
 	e.writeRoleToBackend(t, config)
 	e.IssueCertificateAndSaveSerial(t, data, config)
 }
@@ -970,6 +1236,7 @@ func (e *testEnv) CloudIntegrationIssueCertificateRestricted(t *testing.T) {
 
 	var config = venafiConfigCloud
 
+	e.writeVenafiToBackend(t, config)
 	e.writeRoleToBackend(t, config)
 	e.IssueCertificateAndSaveSerial(t, data, config)
 }
@@ -985,8 +1252,83 @@ func (e *testEnv) CloudIntegrationIssueCertificateWithPassword(t *testing.T) {
 
 	var config = venafiConfigCloud
 
+	e.writeVenafiToBackend(t, config)
 	e.writeRoleToBackend(t, config)
 	e.IssueCertificateAndSaveSerial(t, data, config)
+}
+
+func (e *testEnv) TokenIntegrationIssueCertificate(t *testing.T) {
+
+	data := testData{}
+	randString := e.TestRandString
+	domain := "venafi.example.com"
+	data.cn = randString + "." + domain
+	data.dnsNS = "alt-" + data.cn
+	data.dnsIP = "192.168.1.1"
+	data.dnsEmail = "venafi@example.com"
+
+	var config = venafiConfigToken
+
+	e.writeVenafiToBackend(t, config)
+	e.writeRoleToBackend(t, config)
+	e.IssueCertificateAndSaveSerial(t, data, config)
+
+}
+
+func (e *testEnv) TokenIntegrationIssueCertificateWithPassword(t *testing.T) {
+
+	data := testData{}
+	randString := e.TestRandString
+	domain := "venafi.example.com"
+	data.cn = randString + "." + domain
+	data.dnsNS = "alt-" + data.cn
+	data.dnsIP = "192.168.1.1"
+	data.dnsEmail = "venafi@example.com"
+	data.keyPassword = "Pass0rd!"
+
+	var config = venafiConfigToken
+
+	e.writeVenafiToBackend(t, config)
+	e.writeRoleToBackend(t, config)
+	e.IssueCertificateAndSaveSerial(t, data, config)
+
+}
+
+func (e *testEnv) TokenIntegrationIssueCertificateRestricted(t *testing.T) {
+
+	data := testData{}
+	randString := e.TestRandString
+	domain := "vfidev.com"
+	data.cn = randString + "." + domain
+	data.dnsNS = "alt-" + data.cn
+	data.onlyIP = "192.168.1.1"
+	data.dnsEmail = "venafi@example.com"
+
+	var config = venafiConfigTokenRestricted
+
+	e.writeVenafiToBackend(t, config)
+	e.writeRoleToBackend(t, config)
+	e.IssueCertificateAndSaveSerial(t, data, config)
+
+}
+
+func (e *testEnv) TokenIntegrationSignCertificate(t *testing.T) {
+
+	data := testData{}
+	randString := e.TestRandString
+	domain := "vfidev.com"
+	data.cn = randString + "." + domain
+	data.dnsNS = "alt-" + data.cn
+	data.dnsIP = "127.0.0.1"
+	data.onlyIP = "192.168.0.1"
+	data.signCSR = true
+
+	var config = venafiConfigToken
+
+	e.writeVenafiToBackend(t, config)
+	e.writeRoleToBackend(t, config)
+	e.SignCertificate(t, data, config)
+
 }
 
 func checkStandartCert(t *testing.T, data testData) {
@@ -1073,11 +1415,12 @@ func newIntegrationTestEnv() (*testEnv, error) {
 	}
 
 	return &testEnv{
-		Backend:        b,
-		Context:        ctx,
-		Storage:        config.StorageView,
-		TestRandString: randSeq(9),
-		RoleName:       randSeq(9) + "-role",
+		Backend:          b,
+		Context:          ctx,
+		Storage:          config.StorageView,
+		TestRandString:   randSeq(9),
+		RoleName:         randSeq(9) + "-role",
+		VenafiSecretName: randSeq(9) + "-venafi",
 	}, nil
 }
 

--- a/plugin/pki/path_credentials.go
+++ b/plugin/pki/path_credentials.go
@@ -1,0 +1,301 @@
+package pki
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+func pathCredentialsList(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: CredentialsRootPath + "?$",
+		Fields:  nil,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Callback: b.pathVenafiSecretList,
+				Summary:  "List all venafi secrets",
+			},
+		},
+		HelpSynopsis:    "",
+		HelpDescription: "",
+	}
+}
+
+func pathCredentials(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: CredentialsRootPath + framework.GenericNameRegex("name"),
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Description: "Name of the authentication object",
+				Required:    true,
+			},
+			"tpp_url": {
+				Type:        framework.TypeString,
+				Description: `URL of Venafi Platform. Example: https://tpp.venafi.example/vedsdk`,
+				Deprecated:  true,
+			},
+			"url": {
+				Type:        framework.TypeString,
+				Description: `URL of Venafi Platform. Example: https://tpp.venafi.example/vedsdk, is replacing tpp_url`,
+				Required:    true,
+			},
+
+			"cloud_url": {
+				Type:        framework.TypeString,
+				Description: `URL for Venafi Cloud. Set it only if you want to use non production Cloud`,
+			},
+			"tpp_user": {
+				Type:        framework.TypeString,
+				Description: `web API user for Venafi Platform Example: admin`,
+				Deprecated:  true,
+			},
+			"tpp_password": {
+				Type:        framework.TypeString,
+				Description: `Password for web API user Example: password`,
+				Deprecated:  true,
+			},
+			"access_token": {
+				Type:        framework.TypeString,
+				Description: `Access token for TPP, user should use this for authentication`,
+			},
+			"refresh_token": {
+				Type:        framework.TypeString,
+				Description: `Refresh token for updating access TPP token`,
+			},
+			"trust_bundle_file": {
+				Type: framework.TypeString,
+				Description: `Use to specify a PEM formatted file with certificates to be used as trust anchors when communicating with the remote server.
+								Example:
+  									trust_bundle_file = "/full/path/to/bundle.pem""`,
+			},
+			"apikey": {
+				Type:        framework.TypeString,
+				Description: `API key for Venafi Cloud. Example: 142231b7-cvb0-412e-886b-6aeght0bc93d`,
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathVenafiSecretRead,
+				Summary:  "Read the properties of a venafi secret and displays it to the user.",
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathVenafiSecretCreate,
+				Summary:  "Create a venafi secret",
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.pathVenafiSecretDelete,
+				Summary:  "Delete a venafi secret",
+			},
+		},
+		HelpSynopsis:    "",
+		HelpDescription: "",
+	}
+}
+
+const (
+	CredentialsRootPath   = `venafi/`
+	tokenMode             = `TPP Token (access_token, refresh_token)`
+	tppMode               = `TPP Credentials (tpp_user, tpp_password)`
+	cloudMode             = `Cloud API Key (apikey)`
+	errorMultiModeMessage = `can't specify both: %s and %s modes in the same venafi secret`
+	errorTextURLEmpty     = `url argument required`
+	errorTextInvalidMode  = "invalid mode. fakemode or apikey or tpp credentials or tpp access token required"
+)
+
+var (
+	errorTextMixedTPPAndToken   = fmt.Sprintf(errorMultiModeMessage, tppMode, tokenMode)
+	errorTextMixedTPPAndCloud   = fmt.Sprintf(errorMultiModeMessage, tppMode, cloudMode)
+	errorTextMixedTokenAndCloud = fmt.Sprintf(errorMultiModeMessage, tokenMode, cloudMode)
+)
+
+func (b *backend) pathVenafiSecretList(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	entries, err := req.Storage.List(ctx, CredentialsRootPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return logical.ListResponse(entries), nil
+}
+
+func (b *backend) pathVenafiSecretRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	policyName := data.Get("name").(string)
+	if policyName == "" {
+		return logical.ErrorResponse("missing policy name"), nil
+	}
+
+	cred, err := b.getCredentials(ctx, req.Storage, policyName)
+	if err != nil {
+		return nil, err
+	}
+	if cred == nil {
+		return nil, nil
+	}
+	resp := &logical.Response{
+		Data: cred.ToResponseData(),
+	}
+
+	return resp, nil
+}
+
+func (b *backend) pathVenafiSecretDelete(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	err := req.Storage.Delete(ctx, CredentialsRootPath+data.Get("name").(string))
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (b *backend) pathVenafiSecretCreate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	var err error
+	name := data.Get("name").(string)
+
+	url := data.Get("url").(string)
+	if url == "" {
+		url = data.Get("tpp_url").(string)
+	}
+	if url == "" {
+		url = data.Get("cloud_url").(string)
+	}
+
+	entry := &credentialsEntry{
+		TppUser:         data.Get("tpp_user").(string),
+		TppPassword:     data.Get("tpp_password").(string),
+		URL:             url,
+		AccessToken:     data.Get("access_token").(string),
+		RefreshToken:    data.Get("refresh_token").(string),
+		Apikey:          data.Get("apikey").(string),
+		TrustBundleFile: data.Get("trust_bundle_file").(string),
+	}
+
+	err = validateCredentialsEntry(entry)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+
+	//Store it
+	jsonEntry, err := logical.StorageEntryJSON(CredentialsRootPath+name, entry)
+	if err != nil {
+		return nil, err
+	}
+
+	err = req.Storage.Put(ctx, jsonEntry)
+	if err != nil {
+		return nil, err
+	}
+
+	var logResp *logical.Response
+
+	//respData := map[string]interface{}{}
+
+	warnings := getWarnings(entry, name)
+
+	if cap(warnings) > 0 {
+		logResp = &logical.Response{
+
+			Data:     map[string]interface{}{},
+			Redirect: "",
+			Warnings: warnings,
+		}
+		return logResp, nil
+	}
+
+	return nil, nil
+}
+
+func (b *backend) getCredentials(ctx context.Context, s logical.Storage, name string) (*credentialsEntry, error) {
+	entry, err := s.Get(ctx, CredentialsRootPath+name)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+
+	var result credentialsEntry
+	err = entry.DecodeJSON(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func validateCredentialsEntry(entry *credentialsEntry) error {
+	if entry.Apikey == "" && (entry.TppUser == "" || entry.TppPassword == "") && entry.AccessToken == "" {
+		return fmt.Errorf(errorTextInvalidMode)
+	}
+
+	if entry.URL == "" {
+		return fmt.Errorf(errorTextURLEmpty)
+	}
+
+	if entry.TppUser != "" && entry.Apikey != "" {
+		return fmt.Errorf(errorTextMixedTPPAndCloud)
+	}
+
+	if entry.TppUser != "" && entry.AccessToken != "" {
+		return fmt.Errorf(errorTextMixedTPPAndToken)
+	}
+
+	if entry.AccessToken != "" && entry.Apikey != "" {
+		return fmt.Errorf(errorTextMixedTokenAndCloud)
+	}
+
+	return nil
+}
+
+func getWarnings(entry *credentialsEntry, name string) []string {
+
+	warnings := []string{}
+
+	if entry.TppUser != "" {
+		warnings = append(warnings, "Role: "+name+", saved successfully, but tpp_user is deprecated, please use access_token token instead")
+	}
+	if entry.TppPassword != "" {
+		warnings = append(warnings, "Role: "+name+", saved successfully, but tpp_password is deprecated, please use access_token instead")
+	}
+
+	return warnings
+}
+
+type credentialsEntry struct {
+	TppUser         string `json:"tpp_user"`
+	TppPassword     string `json:"tpp_password"`
+	URL             string `json:"url"`
+	AccessToken     string `json:"access_token"`
+	RefreshToken    string `json:"refresh_token"`
+	Apikey          string `json:"apikey"`
+	TrustBundleFile string `json:"trust_bundle_file"`
+}
+
+func (p *credentialsEntry) ToResponseData() map[string]interface{} {
+	var tppPass, accessToken, refreshToken, apiKey string
+	if p.TppPassword != "" {
+		tppPass = "********"
+	}
+	if p.AccessToken != "" {
+		accessToken = "********"
+	}
+	if p.RefreshToken != "" {
+		refreshToken = "********"
+	}
+	if p.Apikey != "" {
+		apiKey = "********"
+	}
+
+	responseData := map[string]interface{}{
+		//Sensible data will not be returned.
+		//tpp_password, api_key, access_token, refresh_token
+
+		"url":               p.URL,
+		"tpp_user":          p.TppUser,
+		"tpp_password":      tppPass,
+		"access_token":      accessToken,
+		"refresh_token":     refreshToken,
+		"api_key":           apiKey,
+		"trust_bundle_file": p.TrustBundleFile,
+	}
+	return responseData
+}

--- a/plugin/pki/path_roles.go
+++ b/plugin/pki/path_roles.go
@@ -162,12 +162,25 @@ attached to them. Defaults to "false".`,
 				Description: "Timeout of waiting certificate",
 				Default:     180,
 			},
+			"update_if_exist": {
+				Type:        framework.TypeBool,
+				Description: `If a role exist and this parameter is true then the role will be overridden`,
+			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ReadOperation:   b.pathRoleRead,
-			logical.UpdateOperation: b.pathRoleCreate,
-			logical.DeleteOperation: b.pathRoleDelete,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathRoleRead,
+				Summary:  "Read the properties of a role and displays it to the user.",
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathRoleCreate,
+				Summary:  "Create a role if not exist and updates it if exists",
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.pathRoleDelete,
+				Summary:  "Delete a role",
+			},
 		},
 
 		HelpSynopsis:    pathRoleHelpSyn,
@@ -185,7 +198,9 @@ const (
 	errorTextNoStoreAndStoreByCNOrSerialConflict = `Can't specify both no_store and store_by_cn or store_by_serial options '`
 	errorTextNoStoreAndStoreByConflict           = `Can't specify both no_store and store_by options '`
 	errTextStoreByWrongOption                    = "Option store_by can be %s or %s, not %s"
-	errorTextMixedTPPTokenAndCloudAPIKey         = `TPP Token and Cloud API key can't be specified in one role`
+	/* #nosec */
+	errorTextMixedURLAndTokenUrl                 = `tpp_url and url can't be specified in one role`
+	errorAccessTokenOrUrlEmpty                   = `Access Token and URL should have a value`
 )
 
 func (b *backend) getRole(ctx context.Context, s logical.Storage, n string) (*roleEntry, error) {
@@ -243,11 +258,210 @@ func (b *backend) pathRoleList(ctx context.Context, req *logical.Request, d *fra
 	return logical.ListResponse(entries), nil
 }
 
-func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	var err error
+func (b *backend) pathRoleUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	name := data.Get("name").(string)
+	entry, _ := b.getRole(ctx, req.Storage, name)
 
-	entry := &roleEntry{
+	_, isSet := data.GetOk("tpp_url")
+	tpp_url := data.Get("tpp_url").(string)
+	if isSet && (entry.TPPURL != tpp_url) {
+		entry.TPPURL = tpp_url
+	}
+
+	_, isSet = data.GetOk("url")
+	url := data.Get("url").(string)
+	if isSet && (entry.URL != url) {
+		entry.URL = url
+	}
+
+	_, isSet = data.GetOk("cloud_url")
+	cloud_url := data.Get("cloud_url").(string)
+	if isSet && (entry.CloudURL != cloud_url) {
+		entry.CloudURL = cloud_url
+	}
+
+	_, isSet = data.GetOk("zone")
+	zone := data.Get("zone").(string)
+	if isSet && (entry.Zone != zone) {
+		entry.Zone = zone
+	}
+
+	_, isSet = data.GetOk("tpp_password")
+	tpp_password := data.Get("tpp_password").(string)
+	if isSet && (entry.TPPPassword != tpp_password) {
+		entry.TPPPassword = tpp_password
+	}
+
+	_, isSet = data.GetOk("access_token")
+	access_token := data.Get("access_token").(string)
+	if isSet && (entry.AccessToken != access_token) {
+		entry.AccessToken = access_token
+	}
+
+	_, isSet = data.GetOk("refresh_token")
+	refresh_token := data.Get("refresh_token").(string)
+	if isSet && (entry.RefreshToken != refresh_token) {
+		entry.RefreshToken = refresh_token
+	}
+
+	_, isSet = data.GetOk("apikey")
+	apikey := data.Get("apikey").(string)
+	if isSet && (entry.Apikey != apikey) {
+		entry.Apikey = apikey
+	}
+
+	_, isSet = data.GetOk("tpp_user")
+	tpp_user := data.Get("tpp_user").(string)
+	if isSet && (entry.TPPUser != tpp_user) {
+		entry.TPPUser = tpp_user
+	}
+
+	_, isSet = data.GetOk("trust_bundle_file")
+	trust_bundle_file := data.Get("trust_bundle_file").(string)
+	if isSet && (entry.TrustBundleFile != trust_bundle_file) {
+		entry.TrustBundleFile = trust_bundle_file
+	}
+
+	_, isSet = data.GetOk("fakemode")
+	fakemode := data.Get("fakemode").(bool)
+	if isSet && (entry.Fakemode != fakemode) {
+		entry.Fakemode = fakemode
+	}
+
+	_, isSet = data.GetOk("chain_option")
+	chain_option := data.Get("chain_option").(string)
+	if isSet && (entry.ChainOption != chain_option) {
+		entry.ChainOption = chain_option
+	}
+
+	_, isSet = data.GetOk("store_by_cn")
+	store_by_cn := data.Get("store_by_cn").(bool)
+	if isSet && (entry.StoreByCN != store_by_cn) {
+		entry.StoreByCN = store_by_cn
+	}
+
+	_, isSet = data.GetOk("store_by_serial")
+	store_by_serial := data.Get("store_by_serial").(bool)
+	if isSet && (entry.StoreBySerial != store_by_serial) {
+		entry.StoreBySerial = store_by_serial
+	}
+
+	_, isSet = data.GetOk("store_by")
+	store_by := data.Get("store_by").(string)
+	if isSet && (entry.StoreBy != store_by) {
+		entry.StoreBy = store_by
+	}
+
+	_, isSet = data.GetOk("no_store")
+	no_store := data.Get("no_store").(bool)
+	if isSet && (entry.NoStore != no_store) {
+		entry.NoStore = no_store
+	}
+
+	_, isSet = data.GetOk("service_generated_cert")
+	service_generated_cert := data.Get("service_generated_cert").(bool)
+	if isSet && (entry.ServiceGenerated != service_generated_cert) {
+		entry.ServiceGenerated = service_generated_cert
+	}
+
+	_, isSet = data.GetOk("store_pkey")
+	store_pkey := data.Get("store_pkey").(bool)
+	if isSet && (entry.StorePrivateKey != store_pkey) {
+		entry.StorePrivateKey = store_pkey
+	}
+
+	_, isSet = data.GetOk("key_type")
+	key_type := data.Get("key_type").(string)
+	if isSet && (entry.KeyType != key_type) {
+		entry.KeyType = key_type
+	}
+
+	_, isSet = data.GetOk("key_bits")
+	key_bits := data.Get("key_bits").(int)
+	if isSet && (entry.KeyBits != key_bits) {
+		entry.KeyBits = key_bits
+	}
+
+	_, isSet = data.GetOk("key_curve")
+	key_curve := data.Get("key_curve").(string)
+	if isSet && (entry.KeyCurve != key_curve) {
+		entry.KeyCurve = key_curve
+	}
+
+	_, isSet = data.GetOk("max_ttl")
+	max_ttl := time.Duration(data.Get("max_ttl").(int)) * time.Second
+	if isSet && (entry.MaxTTL != max_ttl) {
+		entry.MaxTTL = max_ttl
+	}
+
+	_, isSet = data.GetOk("ttl")
+	ttl := time.Duration(data.Get("ttl").(int)) * time.Second
+	if isSet && (entry.TTL != ttl) {
+		entry.TTL = ttl
+	}
+
+	_, isSet = data.GetOk("generate_lease")
+	generate_lease := data.Get("generate_lease").(bool)
+	if isSet && (entry.GenerateLease != generate_lease) {
+		entry.GenerateLease = generate_lease
+	}
+
+	_, isSet = data.GetOk("server_timeout")
+	server_timeout := time.Duration(data.Get("server_timeout").(int)) * time.Second
+	if isSet && (entry.ServerTimeout != server_timeout) {
+		entry.ServerTimeout = server_timeout
+	}
+	err := validateEntry(entry)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+
+
+	// Store it
+	jsonEntry, err := logical.StorageEntryJSON("role/"+name, entry)
+	if err != nil {
+		return nil, err
+	}
+	if err := req.Storage.Put(ctx, jsonEntry); err != nil {
+		return nil, err
+	}
+
+
+	var logResp *logical.Response
+
+	respData := map[string]interface{}{
+	}
+
+	warnings := getWarnings(entry, name)
+
+	if cap(warnings) > 0 {
+		logResp = &logical.Response{
+
+			Data:     respData,
+			Redirect: "",
+			Warnings: warnings,
+		}
+		return logResp, nil
+	}
+
+	return nil, nil
+}
+
+func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+
+	name := data.Get("name").(string)
+	update := data.Get("update_if_exist").(bool)
+
+	entry, _ := b.getRole(ctx, req.Storage, name)
+
+	if (entry != nil) && update {
+		return b.pathRoleUpdate(ctx, req, data)
+	}
+
+	var err error
+
+
+	entry = &roleEntry{
 		TPPURL:           data.Get("tpp_url").(string),
 		URL:              data.Get("url").(string),
 		CloudURL:         data.Get("cloud_url").(string),
@@ -315,6 +529,26 @@ func validateEntry(entry *roleEntry) (err error) {
 		return fmt.Errorf(errorTextInvalidMode)
 	}
 
+	if entry.TPPURL != "" && entry.URL != "" {
+		return fmt.Errorf(errorTextMixedURLAndTokenUrl)
+	}
+
+	if entry.URL != "" && entry.AccessToken == "" {
+		return fmt.Errorf(errorAccessTokenOrUrlEmpty)
+	}
+
+	if entry.URL == "" && entry.AccessToken != "" {
+		return fmt.Errorf(errorAccessTokenOrUrlEmpty)
+	}
+
+	if entry.Apikey != "" && entry.URL != "" {
+		return fmt.Errorf(errorTextTPPandCloudMixedCredentials)
+	}
+
+	if entry.Apikey != "" && entry.AccessToken != "" {
+		return fmt.Errorf(errorTextTPPandCloudMixedCredentials)
+	}
+
 	if entry.MaxTTL > 0 && entry.TTL > entry.MaxTTL {
 		return fmt.Errorf(
 			errorTextValueMustBeLess,
@@ -330,7 +564,7 @@ func validateEntry(entry *roleEntry) (err error) {
 	}
 
 	if entry.AccessToken != "" && entry.Apikey != "" {
-		return fmt.Errorf(errorTextMixedTPPTokenAndCloudAPIKey)
+		return fmt.Errorf(errorTextTPPandCloudMixedCredentials)
 	}
 
 	if (entry.StoreByCN || entry.StoreBySerial) && entry.StoreBy != "" {
@@ -421,7 +655,7 @@ type roleEntry struct {
 func (r *roleEntry) ToResponseData() map[string]interface{} {
 	responseData := map[string]interface{}{
 		//Venafi
-		"url":   r.URL,
+		"tpp_url":   r.TPPURL,
 		"cloud_url": r.CloudURL,
 		"zone":      r.Zone,
 		//We shouldn't show credentials

--- a/plugin/pki/path_roles_test.go
+++ b/plugin/pki/path_roles_test.go
@@ -158,4 +158,17 @@ func TestRoleValidate(t *testing.T) {
 	if entry.StoreBy != storeByCNString {
 		t.Fatalf("Expecting store_by parameter will be set to %s", storeBySerialString)
 	}
+
+	entry = &roleEntry{
+		URL:         "https://qa-tpp.exmple.com/vedsdk",
+		AccessToken: "abcderffsdsdsd",
+		RefreshToken: "wxyz",
+	}
+
+	err = validateEntry(entry)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
 }

--- a/plugin/pki/path_roles_test.go
+++ b/plugin/pki/path_roles_test.go
@@ -135,6 +135,6 @@ func TestRoleValidate(t *testing.T) {
 	}
 
 	if entry.StoreBy != storeByCNString {
-		t.Fatalf("Expecting store_by parameter will be set to %s", storeBySerialString)
+		t.Fatalf("Expecting store_by parameter will be set to %s", storeByCNString)
 	}
 }

--- a/plugin/pki/path_roles_test.go
+++ b/plugin/pki/path_roles_test.go
@@ -7,24 +7,20 @@ import (
 
 func TestRoleValidate(t *testing.T) {
 
-	entry := &roleEntry{
-		TPPURL: "https://ha-tpp12.sqlha.com:5008/vedsdk",
-	}
+	entry := &roleEntry{}
 
 	err := validateEntry(entry)
 	if err == nil {
 		t.Fatalf("Expecting error")
 	}
-	if err.Error() != errorTextInvalidMode {
+	if err.Error() != errorTextVenafiSecretEmpty {
 		t.Fatalf("Expecting error %s but got %s", errorTextInvalidMode, err)
 	}
 
 	entry = &roleEntry{
-		TPPURL:      "https://qa-tpp.exmple.com/vedsdk",
-		TPPUser:     "admin",
-		TPPPassword: "xxxx",
-		TTL:         120,
-		MaxTTL:      100,
+		VenafiSecret: "testSecret",
+		TTL:          120,
+		MaxTTL:       100,
 	}
 
 	err = validateEntry(entry)
@@ -36,24 +32,9 @@ func TestRoleValidate(t *testing.T) {
 	}
 
 	entry = &roleEntry{
-		TPPURL:      "https://qa-tpp.exmple.com/vedsdk",
-		Apikey:      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		TPPUser:     "admin",
-		TPPPassword: "xxxx",
-	}
-
-	err = validateEntry(entry)
-	if err == nil {
-		t.Fatalf("Expecting error")
-	}
-	if err.Error() != errorTextTPPandCloudMixedCredentials {
-		t.Fatalf("Expecting error %s but got %s", errorTextTPPandCloudMixedCredentials, err)
-	}
-
-	entry = &roleEntry{
-		Apikey:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		StoreByCN: true,
-		StoreBy:   "cn",
+		VenafiSecret: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		StoreByCN:    true,
+		StoreBy:      "cn",
 	}
 	err = validateEntry(entry)
 	if err == nil {
@@ -64,7 +45,7 @@ func TestRoleValidate(t *testing.T) {
 	}
 
 	entry = &roleEntry{
-		Apikey:        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		VenafiSecret:  "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 		StoreBySerial: true,
 		StoreBy:       "cn",
 	}
@@ -77,7 +58,7 @@ func TestRoleValidate(t *testing.T) {
 	}
 
 	entry = &roleEntry{
-		Apikey:        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		VenafiSecret:  "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 		StoreBySerial: true,
 		StoreByCN:     true,
 		StoreBy:       "cn",
@@ -91,7 +72,7 @@ func TestRoleValidate(t *testing.T) {
 	}
 
 	entry = &roleEntry{
-		Apikey:        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		VenafiSecret:  "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 		StoreBySerial: true,
 		StoreByCN:     true,
 		NoStore:       true,
@@ -105,9 +86,9 @@ func TestRoleValidate(t *testing.T) {
 	}
 
 	entry = &roleEntry{
-		Apikey:  "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		StoreBy: "serial",
-		NoStore: true,
+		VenafiSecret: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		StoreBy:      "serial",
+		NoStore:      true,
 	}
 	err = validateEntry(entry)
 	if err == nil {
@@ -118,8 +99,8 @@ func TestRoleValidate(t *testing.T) {
 	}
 
 	entry = &roleEntry{
-		Apikey:  "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		StoreBy: "sebial",
+		VenafiSecret: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		StoreBy:      "sebial",
 	}
 	err = validateEntry(entry)
 	if err == nil {
@@ -131,10 +112,9 @@ func TestRoleValidate(t *testing.T) {
 	}
 
 	entry = &roleEntry{
-		Apikey:        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		VenafiSecret:  "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 		StoreBySerial: true,
 		StoreByCN:     true,
-
 	}
 	err = validateEntry(entry)
 	if err != nil {
@@ -146,9 +126,8 @@ func TestRoleValidate(t *testing.T) {
 	}
 
 	entry = &roleEntry{
-		Apikey:        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		StoreByCN:     true,
-
+		VenafiSecret: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		StoreByCN:    true,
 	}
 	err = validateEntry(entry)
 	if err != nil {
@@ -158,17 +137,4 @@ func TestRoleValidate(t *testing.T) {
 	if entry.StoreBy != storeByCNString {
 		t.Fatalf("Expecting store_by parameter will be set to %s", storeBySerialString)
 	}
-
-	entry = &roleEntry{
-		URL:         "https://qa-tpp.exmple.com/vedsdk",
-		AccessToken: "abcderffsdsdsd",
-		RefreshToken: "wxyz",
-	}
-
-	err = validateEntry(entry)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
 }

--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -118,7 +118,7 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request
 	// a storage call is made after the API calls to issue the certificate.  This prevents the certificate from being
 	// issued twice in this scenario.
 	if !role.NoStore && b.System().ReplicationState().
-		HasState(consts.ReplicationPerformanceStandby | consts.ReplicationPerformanceSecondary) {
+		HasState(consts.ReplicationPerformanceStandby|consts.ReplicationPerformanceSecondary) {
 		return nil, logical.ErrReadOnly
 	}
 
@@ -179,7 +179,7 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request
 		//validate if the error is related to a expired accces token, at this moment the only way can validate this is using the error message
 		//and verify if that message describes errors related to expired access token.
 		if (strings.Contains(msg, "\"error\":\"expired_token\"") && strings.Contains(msg, "\"error_description\":\"Access token expired\"")) || regex.MatchString(msg) {
-			cfg, err := b.getConfig(ctx, req.Storage, data, req, roleName)
+			cfg, err := b.getConfig(ctx, req, roleName)
 
 			if err != nil {
 				return logical.ErrorResponse(err.Error()), nil
@@ -192,7 +192,7 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request
 					return logical.ErrorResponse(err.Error()), nil
 				}
 
-				//everything went fine so get the new client with the new refreshed acces token
+				//everything went fine so get the new client with the new refreshed access token
 				cl, timeout, err = b.ClientVenafi(ctx, req.Storage, data, req, roleName)
 				if err != nil {
 					return logical.ErrorResponse(err.Error()), nil

--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -179,7 +179,7 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request
 		//validate if the error is related to a expired accces token, at this moment the only way can validate this is using the error message
 		//and verify if that message describes errors related to expired access token.
 		if (strings.Contains(msg, "\"error\":\"expired_token\"") && strings.Contains(msg, "\"error_description\":\"Access token expired\"")) || regex.MatchString(msg) {
-			cfg, err := b.getConfig(ctx, req, roleName)
+			cfg, err := b.getConfig(ctx, req, roleName, true)
 
 			if err != nil {
 				return logical.ErrorResponse(err.Error()), nil

--- a/plugin/pki/path_venafi_secrets.go
+++ b/plugin/pki/path_venafi_secrets.go
@@ -45,7 +45,7 @@ Example for Venafi Cloud: e33f3e40-4e7e-11ea-8da3-b3c196ebeb0b`,
 			},
 			"url": {
 				Type:        framework.TypeString,
-				Description: `URL of Venafi Platform. Example: https://tpp.venafi.example/vedsdk, is replacing tpp_url`,
+				Description: `URL of Venafi Platform. It replaces tpp_url and cloud_url. Example: https://tpp.venafi.example`,
 				Required:    true,
 			},
 
@@ -208,8 +208,6 @@ func (b *backend) pathVenafiSecretCreate(ctx context.Context, req *logical.Reque
 	}
 
 	var logResp *logical.Response
-
-	//respData := map[string]interface{}{}
 
 	warnings := getWarnings(entry, name)
 

--- a/plugin/pki/path_venafi_secrets.go
+++ b/plugin/pki/path_venafi_secrets.go
@@ -40,18 +40,18 @@ Example for Venafi Cloud: e33f3e40-4e7e-11ea-8da3-b3c196ebeb0b`,
 			},
 			"tpp_url": {
 				Type:        framework.TypeString,
-				Description: `URL of Venafi Platform. Example: https://tpp.venafi.example/vedsdk`,
+				Description: `URL of Venafi Platform. Example: https://tpp.venafi.example/vedsdk. Deprecated, use 'url' instead`,
 				Deprecated:  true,
 			},
 			"url": {
 				Type:        framework.TypeString,
-				Description: `URL of Venafi Platform. It replaces tpp_url and cloud_url. Example: https://tpp.venafi.example`,
+				Description: `URL of Venafi API Endpoint. Example: https://tpp.venafi.example`,
 				Required:    true,
 			},
 
 			"cloud_url": {
 				Type:        framework.TypeString,
-				Description: `URL for Venafi Cloud. Set it only if you want to use non production Cloud`,
+				Description: `URL for Venafi Cloud. Set it only if you want to use non production Cloud. Deprecated, use 'url' instead`,
 				Deprecated:  true,
 			},
 			"tpp_user": {

--- a/plugin/pki/path_venafi_secrets_test.go
+++ b/plugin/pki/path_venafi_secrets_test.go
@@ -1,0 +1,87 @@
+package pki
+
+import "testing"
+
+func TestVenafiSecretValidate(t *testing.T) {
+	entry := &venafiSecretEntry{}
+
+	err := validateVenafiSecretEntry(entry)
+	if err == nil {
+		t.Fatalf("Expecting error")
+	}
+	if err.Error() != errorTextInvalidMode {
+		t.Fatalf("Expecting error %s but got %s", errorTextInvalidMode, err)
+	}
+
+	entry = &venafiSecretEntry{
+		AccessToken: "foo123bar==",
+	}
+
+	err = validateVenafiSecretEntry(entry)
+	if err == nil {
+		t.Fatalf("Expecting error")
+	}
+	if err.Error() != errorTextURLEmpty {
+		t.Fatalf("Expecting error %s but got %s", errorTextURLEmpty, err)
+	}
+
+	entry = &venafiSecretEntry{
+		URL:         "https://ha-tpp12.sqlha.com:5008/vedsdk",
+		AccessToken: "foo123bar==",
+	}
+
+	err = validateVenafiSecretEntry(entry)
+	if err == nil {
+		t.Fatalf("Expecting error")
+	}
+	if err.Error() != errorTextZoneEmpty {
+		t.Fatalf("Expecting error %s but got %s", errorTextZoneEmpty, err)
+	}
+
+	entry = &venafiSecretEntry{
+		URL:         "https://qa-tpp.exmple.com/vedsdk",
+		Zone:        "devops\\vcert",
+		Apikey:      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		TppUser:     "admin",
+		TppPassword: "xxxx",
+	}
+
+	err = validateVenafiSecretEntry(entry)
+	if err == nil {
+		t.Fatalf("Expecting error")
+	}
+	if err.Error() != errorTextMixedTPPAndCloud {
+		t.Fatalf("Expecting error %s but got %s", errorTextMixedTPPAndCloud, err)
+	}
+
+	entry = &venafiSecretEntry{
+		URL:         "https://qa-tpp.exmple.com/vedsdk",
+		Zone:        "devops\\vcert",
+		AccessToken: "foo123bar==",
+		TppUser:     "admin",
+		TppPassword: "xxxx",
+	}
+
+	err = validateVenafiSecretEntry(entry)
+	if err == nil {
+		t.Fatalf("Expecting error")
+	}
+	if err.Error() != errorTextMixedTPPAndToken {
+		t.Fatalf("Expecting error %s but got %s", errorTextMixedTPPAndToken, err)
+	}
+
+	entry = &venafiSecretEntry{
+		URL:         "https://qa-tpp.exmple.com/vedsdk",
+		Zone:        "devops\\vcert",
+		AccessToken: "foo123bar==",
+		Apikey:      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+	}
+
+	err = validateVenafiSecretEntry(entry)
+	if err == nil {
+		t.Fatalf("Expecting error")
+	}
+	if err.Error() != errorTextMixedTokenAndCloud {
+		t.Fatalf("Expecting error %s but got %s", errorTextMixedTokenAndCloud, err)
+	}
+}

--- a/plugin/pki/util.go
+++ b/plugin/pki/util.go
@@ -166,11 +166,20 @@ func storeAccessData(b *backend, ctx context.Context, req *logical.Request, role
 		return err
 	}
 
-	entry.RefreshToken = resp.Refresh_token
-	entry.AccessToken = resp.Access_token
+	if entry.VenafiSecret == "" {
+		return fmt.Errorf("Role " + roleName + " does not have any Venafi secret associated")
+	}
+
+	venafiEntry, err := b.getCredentials(ctx, req.Storage, entry.VenafiSecret)
+	if err != nil {
+		return err
+	}
+
+	venafiEntry.AccessToken = resp.Access_token
+	venafiEntry.RefreshToken = resp.Refresh_token
 
 	// Store it
-	jsonEntry, err := logical.StorageEntryJSON("role/"+roleName, entry)
+	jsonEntry, err := logical.StorageEntryJSON(CredentialsRootPath+entry.VenafiSecret, venafiEntry)
 	if err != nil {
 		return err
 	}

--- a/plugin/pki/util.go
+++ b/plugin/pki/util.go
@@ -53,9 +53,12 @@ type RunContext struct {
 	CloudUrl            string
 	CloudAPIkey         string
 	CloudZone           string
+	TokenUrl            string
+	AccessToken         string
 	TPPTestingEnabled   bool
 	CloudTestingEnabled bool
 	FakeTestingEnabled  bool
+	TokenTestingEnabled bool
 	TPPIssuerCN         string
 	CloudIssuerCN       string
 	FakeIssuerCN        string
@@ -73,9 +76,15 @@ func GetContext() *RunContext {
 	c.CloudUrl = os.Getenv("CLOUD_URL")
 	c.CloudAPIkey = os.Getenv("CLOUD_APIKEY")
 	c.CloudZone = os.Getenv("CLOUD_ZONE")
+
+	c.TokenUrl = os.Getenv("TPP_TOKEN_URL")
+	c.AccessToken = os.Getenv("ACCESS_TOKEN")
+
 	c.TPPTestingEnabled, _ = strconv.ParseBool(os.Getenv("VENAFI_TPP_TESTING"))
 	c.CloudTestingEnabled, _ = strconv.ParseBool(os.Getenv("VENAFI_CLOUD_TESTING"))
 	c.FakeTestingEnabled, _ = strconv.ParseBool(os.Getenv("VENAFI_FAKE_TESTING"))
+	c.TokenTestingEnabled, _ = strconv.ParseBool(os.Getenv("VENAFI_TPP_TOKEN_TESTING"))
+
 	c.TPPIssuerCN = os.Getenv("TPP_ISSUER_CN")
 	c.CloudIssuerCN = os.Getenv("CLOUD_ISSUER_CN")
 	c.FakeIssuerCN = os.Getenv("FAKE_ISSUER_CN")
@@ -170,7 +179,7 @@ func storeAccessData(b *backend, ctx context.Context, req *logical.Request, role
 		return fmt.Errorf("Role " + roleName + " does not have any Venafi secret associated")
 	}
 
-	venafiEntry, err := b.getCredentials(ctx, req.Storage, entry.VenafiSecret)
+	venafiEntry, err := b.getVenafiSecret(ctx, req.Storage, entry.VenafiSecret)
 	if err != nil {
 		return err
 	}

--- a/plugin/pki/vcert.go
+++ b/plugin/pki/vcert.go
@@ -72,14 +72,27 @@ func (b *backend) ClientVenafi(ctx context.Context, s logical.Storage, data *fra
 		}
 
 	} else if role.URL != "" && role.AccessToken != "" {
+		if trustBundlePEM != "" {
 		cfg = &vcert.Config{
 			ConnectorType: endpoint.ConnectorTypeTPP,
 			BaseUrl:       role.URL,
+			ConnectionTrust: trustBundlePEM,
 			Credentials: &endpoint.Authentication{
 				AccessToken: role.AccessToken,
 			},
 			Zone:       role.Zone,
 			LogVerbose: true,
+		}
+		}else {
+			cfg = &vcert.Config{
+				ConnectorType: endpoint.ConnectorTypeTPP,
+				BaseUrl:       role.URL,
+				Credentials: &endpoint.Authentication{
+					AccessToken: role.AccessToken,
+				},
+				Zone:       role.Zone,
+				LogVerbose: true,
+			}
 		}
 	} else if role.Apikey != "" {
 		b.Logger().Debug("Using Venafi Cloud to issue certificate")
@@ -179,16 +192,29 @@ func (b *backend) getConfig(ctx context.Context, s logical.Storage, data *framew
 		}
 
 	} else if role.URL != "" && role.AccessToken != "" {
-		cfg = &vcert.Config{
-			ConnectorType:   endpoint.ConnectorTypeTPP,
-			BaseUrl:         role.URL,
-			ConnectionTrust: trustBundlePEM,
-			Credentials: &endpoint.Authentication{
-				AccessToken:  role.AccessToken,
-				RefreshToken: role.RefreshToken,
-			},
-			Zone:       role.Zone,
-			LogVerbose: true,
+		if trustBundlePEM != "" {
+			cfg = &vcert.Config{
+				ConnectorType:   endpoint.ConnectorTypeTPP,
+				BaseUrl:         role.URL,
+				ConnectionTrust: trustBundlePEM,
+				Credentials: &endpoint.Authentication{
+					AccessToken:  role.AccessToken,
+					RefreshToken: role.RefreshToken,
+				},
+				Zone:       role.Zone,
+				LogVerbose: true,
+			}
+		}else {
+			cfg = &vcert.Config{
+				ConnectorType:   endpoint.ConnectorTypeTPP,
+				BaseUrl:         role.URL,
+				Credentials: &endpoint.Authentication{
+					AccessToken:  role.AccessToken,
+					RefreshToken: role.RefreshToken,
+				},
+				Zone:       role.Zone,
+				LogVerbose: true,
+			}
 		}
 	} else if role.Apikey != "" {
 		b.Logger().Debug("Using Venafi Cloud to issue certificate")

--- a/plugin/pki/vcert_test.go
+++ b/plugin/pki/vcert_test.go
@@ -85,6 +85,7 @@ func TestPKIVcertConfig(t *testing.T) {
 		"store_by_cn":     "true",
 		"store_pkey":      "true",
 		"store_by_serial": "true",
+		"venafi_secret":   "venafi",
 	}
 
 	roleReq := &logical.Request{


### PR DESCRIPTION
The following changes separate the data inside role secret in two entities, rol secret and venafi secret. The Venafi secret will store all data related to the venafi connection like username, password, url and so. While role will keep the remaining data.
Now is required that a rol references a specific venafi secret in order to execute the other operations.

Tests have been updated accordingly to make use of the new venafi secret.

The venafi secret addresses a very specific use case, when a Rol is provided with access token and refresh token. And the access token expires, the backend plugin will attempt to refresh the token using the refresh one. If successful, the new tokens are saved to the Rol. However, the user no longer knows which are these tokens. If the user decides to "update" the Rol by overriding it (there is no update operation in vault), then the new tokens would be lost and the old ones (known by the user) are no longer valid.

With the new Venafi secret, the backend plugin can refresh the token as many times as required and the user can override the  Rol without loosing the new tokens, given that the Venafi secret is not modified by the rol.