### PR TITLE
Fixed issue in Cloud platform tests. 

### DIFF
--- a/plugin/pki/env_test.go
+++ b/plugin/pki/env_test.go
@@ -1379,12 +1379,6 @@ func checkStandardCert(t *testing.T, data testData) {
 		ips = append(ips, net.ParseIP(data.dnsIP))
 	}
 
-	if data.provider == venafiConfigCloud {
-		//This is a workaround since in cloud used Vault 1.0 as internal CA which is duplicating DNSNames
-		//After test cloud update to Vault > 1.3 we can remove this
-		parsedCertificate.DNSNames = unique(parsedCertificate.DNSNames)
-	}
-
 	if !areDNSNamesCorrect(parsedCertificate.DNSNames, []string{data.cn}, wantDNSNames) {
 		t.Fatalf("Certificate Subject Alternative Names %v doesn't match to requested %v", parsedCertificate.DNSNames, wantDNSNames)
 	}

--- a/plugin/pki/env_test.go
+++ b/plugin/pki/env_test.go
@@ -501,7 +501,7 @@ func (e *testEnv) IssueCertificateAndSaveSerial(t *testing.T, data testData, con
 	//it is need to determine if we're checking cloud signed certificate in checkStandartCert
 	data.provider = configString
 
-	checkStandartCert(t, data)
+	checkStandardCert(t, data)
 
 	//save certificate serial for the next test
 	e.CertificateSerial = resp.Data["serial_number"].(string)
@@ -585,7 +585,7 @@ func (e *testEnv) SignCertificate(t *testing.T, data testData, configString vena
 	data.cert = resp.Data["certificate"].(string)
 	data.provider = configString
 
-	checkStandartCert(t, data)
+	checkStandardCert(t, data)
 }
 
 func (e *testEnv) ReadCertificate(t *testing.T, data testData, configString venafiConfigString, certId string) {
@@ -618,7 +618,7 @@ func (e *testEnv) ReadCertificate(t *testing.T, data testData, configString vena
 
 	data.cert = resp.Data["certificate"].(string)
 	data.privateKey = resp.Data["private_key"].(string)
-	checkStandartCert(t, data)
+	checkStandardCert(t, data)
 
 }
 
@@ -1331,7 +1331,7 @@ func (e *testEnv) TokenIntegrationSignCertificate(t *testing.T) {
 
 }
 
-func checkStandartCert(t *testing.T, data testData) {
+func checkStandardCert(t *testing.T, data testData) {
 	var err error
 	log.Println("Testing certificate:", data.cert)
 	certPEMBlock, _ := pem.Decode([]byte(data.cert))
@@ -1365,7 +1365,7 @@ func checkStandartCert(t *testing.T, data testData) {
 		t.Fatalf("Certificate common name expected to be %s but actualy it is %s", parsedCertificate.Subject.CommonName, data.cn)
 	}
 
-	wantDNSNames := []string{data.cn, data.dnsNS}
+	wantDNSNames := []string{data.dnsNS}
 
 	if data.dnsIP != "" {
 		wantDNSNames = append(wantDNSNames, data.dnsIP)
@@ -1385,7 +1385,7 @@ func checkStandartCert(t *testing.T, data testData) {
 		parsedCertificate.DNSNames = unique(parsedCertificate.DNSNames)
 	}
 
-	if !SameStringSlice(parsedCertificate.DNSNames, wantDNSNames) {
+	if !areDNSNamesCorrect(parsedCertificate.DNSNames, []string{data.cn}, wantDNSNames) {
 		t.Fatalf("Certificate Subject Alternative Names %v doesn't match to requested %v", parsedCertificate.DNSNames, wantDNSNames)
 	}
 

--- a/plugin/pki/util.go
+++ b/plugin/pki/util.go
@@ -130,6 +130,62 @@ func SameStringSlice(x, y []string) bool {
 	return true
 }
 
+func areDNSNamesCorrect(actualAltNames []string, expectedCNNames []string, expectedAltNames []string) bool {
+
+	//There is no cn names. Check expectedAltNames only. Is it possible?
+	if len(expectedCNNames) == 0 {
+		if len(actualAltNames) != len(expectedAltNames) {
+			return false
+
+		} else if !SameStringSlice(actualAltNames, expectedAltNames) {
+			return false
+		}
+	} else {
+
+		//Checking expectedAltNames are in actualAltNames
+		if len(actualAltNames) < len(expectedAltNames) {
+			return false
+		}
+
+		for i := range expectedAltNames {
+			expectedName := expectedAltNames[i]
+			found := false
+
+			for j := range actualAltNames {
+
+				if actualAltNames[j] == expectedName {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+
+		//Checking expectedCNNames
+		allNames := append(expectedAltNames, expectedCNNames...)
+		for i := range actualAltNames {
+			name := actualAltNames[i]
+			found := false
+
+			for j := range allNames {
+
+				if allNames[j] == name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+
+	}
+
+	return true
+}
+
 func getTppConnector(cfg *vcert.Config) (*tpp.Connector, error) {
 
 	var connectionTrustBundle *x509.CertPool


### PR DESCRIPTION
The CN name is no longer returned as part of the DNS names.