### PR TITLE
fix for wrong conversion from ttl to hours and added test to validate

### DIFF
--- a/plugin/pki/backend_test.go
+++ b/plugin/pki/backend_test.go
@@ -159,6 +159,7 @@ func TestTokenIntegration(t *testing.T) {
 	}
 
 	t.Run("TPP Token base enroll", integrationTestEnv.TokenIntegrationIssueCertificate)
+	t.Run("TPP Token base enroll and verify ttl", integrationTestEnv.TokenIntegrationIssueCertificateAndValidateTTL)
 	t.Run("TPP Token base enroll with password", integrationTestEnv.TokenIntegrationIssueCertificateWithPassword)
 	t.Run("TPP Token restricted enroll", integrationTestEnv.TokenIntegrationIssueCertificateRestricted)
 	t.Run("TPP Token sign certificate", integrationTestEnv.TokenIntegrationSignCertificate)

--- a/plugin/pki/path_roles.go
+++ b/plugin/pki/path_roles.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func pathListRoles(b *backend) *framework.Path {
@@ -118,7 +118,7 @@ attached to them. Defaults to "false".`,
 				Required:    true,
 			},
 			"update_if_exist": {
-				Type:        framework.TypeBool,
+				Type: framework.TypeBool,
 				Description: `When true, settings of an existing role will be retained unless they are specified in the update.
                               By default unspecified settings are returned to their default values`,
 			},
@@ -474,11 +474,10 @@ func (r *roleEntry) ToResponseData() map[string]interface{} {
 		"venafi_secret":          r.VenafiSecret,
 		"store_by":               r.StoreBy,
 		"no_store":               r.NoStore,
-		"store_by_cn":            r.StoreByCN,
-		"store_by_serial":        r.StoreBySerial,
 		"service_generated_cert": r.ServiceGenerated,
 		"store_pkey":             r.StorePrivateKey,
 		"ttl":                    int64(r.TTL.Seconds()),
+		"issuer_hint":            r.IssuerHint,
 		"max_ttl":                int64(r.MaxTTL.Seconds()),
 		"generate_lease":         r.GenerateLease,
 		"chain_option":           r.ChainOption,

--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -460,7 +460,9 @@ func formRequest(reqData requestData, role *roleEntry, signCSR bool, logger hclo
 		}
 
 		certReq.IssuerHint = issuerHint
-		certReq.ValidityHours = int(role.TTL)
+
+		ttl := int(role.TTL.Hours())
+		certReq.ValidityHours = ttl
 	}
 
 	//Adding origin custom field with utility name to certificate metadata

--- a/plugin/pki/util.go
+++ b/plugin/pki/util.go
@@ -19,6 +19,10 @@ import (
 	"time"
 )
 
+const (
+	ttl_test_property = int(96)
+)
+
 func sliceContains(slice []string, item string) bool {
 	set := make(map[string]struct{}, len(slice))
 	for _, s := range slice {


### PR DESCRIPTION
this changes fixes:

- wrong conversion from ttl to hours, now works as expected.
- added a test case to validate if ttl matches with certificate's NotAfter , when generating a cerficate.
- when exploring a property of a role using this path: vault read pki-backend/roles/my_role
    - removed store_by_cn and store_by_serial
    - added issuer_hint