### PR TITLE
Adding ttl property on the paths: pki-backend/issue/role_name and pki-backend/sign/role

### DIFF
--- a/plugin/pki/backend_test.go
+++ b/plugin/pki/backend_test.go
@@ -144,6 +144,7 @@ func TestCloudIntegration(t *testing.T) {
 	}
 
 	t.Run("Cloud base enroll", integrationTestEnv.CloudIntegrationIssueCertificate)
+	t.Run("Cloud base enroll and verify ttl", integrationTestEnv.CloudIntegrationIssueCertificateAndVerifyTTL)
 	t.Run("Cloud restricted enroll", integrationTestEnv.CloudIntegrationIssueCertificateRestricted)
 	t.Run("Cloud issue certificate with password", integrationTestEnv.CloudIntegrationIssueCertificateWithPassword)
 	t.Run("Cloud sign certificate", integrationTestEnv.CloudIntegrationSignCertificate)
@@ -161,8 +162,10 @@ func TestTokenIntegration(t *testing.T) {
 	t.Run("TPP Token base enroll", integrationTestEnv.TokenIntegrationIssueCertificate)
 	t.Run("TPP Token base enroll with custom fields", integrationTestEnv.TokenIntegrationIssueCertificateWithCustomFields)
 	t.Run("TPP Token base enroll and verify ttl", integrationTestEnv.TokenIntegrationIssueCertificateAndValidateTTL)
+	t.Run("TPP Token base enroll with ttl on request", integrationTestEnv.TokenIntegrationIssueCertificateWithTTLOnIssueData)
 	t.Run("TPP Token base enroll with password", integrationTestEnv.TokenIntegrationIssueCertificateWithPassword)
 	t.Run("TPP Token restricted enroll", integrationTestEnv.TokenIntegrationIssueCertificateRestricted)
 	t.Run("TPP Token sign certificate", integrationTestEnv.TokenIntegrationSignCertificate)
+	t.Run("TPP Token sign certificate and ttl attribute", integrationTestEnv.TokenIntegrationSignWithTTLCertificate)
 
 }

--- a/plugin/pki/path_roles.go
+++ b/plugin/pki/path_roles.go
@@ -87,10 +87,7 @@ the key_type. Default: 2048`,
 			},
 			"ttl": {
 				Type: framework.TypeDurationSecond,
-				Description: `The lease duration if no specific lease duration is
-requested. The lease duration controls the expiration
-of certificates issued by this backend. Defaults to
-the value of max_ttl.`,
+				Description: `The maximum allowed certificate validity`,
 			},
 			"issuer_hint": {
 				Type:        framework.TypeString,

--- a/plugin/pki/path_roles.go
+++ b/plugin/pki/path_roles.go
@@ -87,7 +87,7 @@ the key_type. Default: 2048`,
 			},
 			"ttl": {
 				Type: framework.TypeDurationSecond,
-				Description: `The maximum allowed certificate validity`,
+				Description: `The certificate validity if no specific certificate validity is requested.`,
 			},
 			"issuer_hint": {
 				Type:        framework.TypeString,
@@ -95,7 +95,7 @@ the key_type. Default: 2048`,
 			},
 			"max_ttl": {
 				Type:        framework.TypeDurationSecond,
-				Description: "The maximum allowed lease duration",
+				Description: "The maximum allowed certificate validity",
 			},
 
 			"generate_lease": {

--- a/plugin/pki/util.go
+++ b/plugin/pki/util.go
@@ -20,7 +20,8 @@ import (
 )
 
 const (
-	ttl_test_property = int(96)
+	role_ttl_test_property = int(120)
+	ttl_test_property      = int(48)
 )
 
 func sliceContains(slice []string, item string) bool {


### PR DESCRIPTION
Now user can user ttl when requesting a certificate using the path: pki-backend/issue/role and when sign a certificate using the path pki-backend/sign/role

if the ttl attribute is set on this paths and on the role, the one is set on the path will be used, if is not set on the path but is set on the role, then the one is set on the role will be used.

Also added test case for each one of this new features.

ran test suite and all test passed.
