### PR TITLE
Adding custom_fields field to pki/sign/:role path

### DIFF
--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -49,8 +49,11 @@ func pathVenafiCertEnroll(b *backend) *framework.Path {
 				Description: "Use to specify custom fields in format 'key=value'. Use comma to separate multiple values: 'key1=value1,key2=value2'",
 			},
 		},
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.pathVenafiIssue,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathVenafiIssue,
+				Summary:  "",
+			},
 		},
 
 		HelpSynopsis:    pathVenafiCertEnrollHelp,
@@ -70,9 +73,16 @@ func pathVenafiCertSign(b *backend) *framework.Path {
 				Type:        framework.TypeString,
 				Description: `The desired role with configuration for this request`,
 			},
+			"custom_fields": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: "Use to specify custom fields in format 'key=value'. Use comma to separate multiple values: 'key1=value1,key2=value2'",
+			},
 		},
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.pathVenafiSign,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathVenafiSign,
+				Summary:  "",
+			},
 		},
 
 		HelpSynopsis:    pathVenafiCertSignHelp,
@@ -186,7 +196,7 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request
 		//catch the scenario when token is expired and deleted.
 		var regex = regexp.MustCompile("(Token).*(not found)")
 
-		//validate if the error is related to a expired accces token, at this moment the only way can validate this is using the error message
+		//validate if the error is related to a expired access token, at this moment the only way can validate this is using the error message
 		//and verify if that message describes errors related to expired access token.
 		if (strings.Contains(msg, "\"error\":\"expired_token\"") && strings.Contains(msg, "\"error_description\":\"Access token expired\"")) || regex.MatchString(msg) {
 			cfg, err := b.getConfig(ctx, req, roleName, true)
@@ -446,7 +456,7 @@ func formRequest(reqData requestData, role *roleEntry, signCSR bool, logger hclo
 	} else if role.ChainOption == "last" {
 		certReq.ChainOption = certificate.ChainOptionRootLast
 	} else {
-		return certReq, fmt.Errorf("Invalid chain option %s", role.ChainOption)
+		return certReq, fmt.Errorf("invalid chain option %s", role.ChainOption)
 	}
 
 	if role.TTL > 0 {
@@ -454,10 +464,10 @@ func formRequest(reqData requestData, role *roleEntry, signCSR bool, logger hclo
 		issuerHint := ""
 
 		if role.IssuerHint != "" {
-			issrOpt := string(role.IssuerHint[0])
-			issrOpt = strings.ToLower(issrOpt)
+			issuerOpt := string(role.IssuerHint[0])
+			issuerOpt = strings.ToLower(issuerOpt)
 
-			switch issrOpt {
+			switch issuerOpt {
 			case "m":
 				issuerHint = util.IssuerHintMicrosoft
 			case "d":


### PR DESCRIPTION
Added the custom_fields field to the sign/:role path in path_venafi_cert_enroll.go 
Now custom fields should be supported just like in path issue/:role

Removed deprecated Callback field in vault path schema, and replaced it with the current Operations field.
Minor changes like typos were fixed as well.