### PR TITLE
Streamline initialization of Secrets Engine with TPP by requiring Refresh Token only

### DIFF
--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -219,13 +219,12 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request
 		msg := err.Error()
 
 		//catch the scenario when token is expired and deleted.
-		var regex = regexp.MustCompile("(Token).*(not found)")
+		var regex = regexp.MustCompile("(expired|invalid)_token")
 
 		//validate if the error is related to a expired access token, at this moment the only way can validate this is using the error message
 		//and verify if that message describes errors related to expired access token.
 		code := getStatusCode(msg)
-		if code == HTTP_UNAUTHORIZED &&
-			((strings.Contains(msg, "\"error\":\"expired_token\"") && strings.Contains(msg, "\"error_description\":\"Access token expired\"")) || regex.MatchString(msg)) {
+		if code == HTTP_UNAUTHORIZED && regex.MatchString(msg){
 			cfg, err := b.getConfig(ctx, req, roleName, true)
 
 			if err != nil {

--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -223,7 +223,8 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request
 
 		//validate if the error is related to a expired access token, at this moment the only way can validate this is using the error message
 		//and verify if that message describes errors related to expired access token.
-		if (strings.Contains(msg, "\"error\":\"expired_token\"") && strings.Contains(msg, "\"error_description\":\"Access token expired\"")) || regex.MatchString(msg) {
+		code := getStatusCode(msg)
+		if code == HTTP_UNAUTHORIZED || regex.MatchString(msg) {
 			cfg, err := b.getConfig(ctx, req, roleName, true)
 
 			if err != nil {

--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -224,7 +224,8 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request
 		//validate if the error is related to a expired access token, at this moment the only way can validate this is using the error message
 		//and verify if that message describes errors related to expired access token.
 		code := getStatusCode(msg)
-		if code == HTTP_UNAUTHORIZED || regex.MatchString(msg) {
+		if code == HTTP_UNAUTHORIZED &&
+			((strings.Contains(msg, "\"error\":\"expired_token\"") && strings.Contains(msg, "\"error_description\":\"Access token expired\"")) || regex.MatchString(msg)) {
 			cfg, err := b.getConfig(ctx, req, roleName, true)
 
 			if err != nil {

--- a/plugin/pki/path_venafi_secrets.go
+++ b/plugin/pki/path_venafi_secrets.go
@@ -195,6 +195,36 @@ func (b *backend) pathVenafiSecretCreate(ctx context.Context, req *logical.Reque
 		return logical.ErrorResponse(err.Error()), nil
 	}
 
+	if entry.RefreshToken != "" {
+
+		cfg, err := createConfigFromFieldData(entry)
+
+		if err != nil {
+
+			return logical.ErrorResponse(err.Error()), nil
+
+		}
+
+		tokenInfo, err := getAccessData(cfg)
+
+		if err != nil {
+
+			return logical.ErrorResponse(err.Error()), nil
+
+		} else {
+
+			if tokenInfo.Access_token != "" {
+				entry.AccessToken = tokenInfo.Access_token
+			}
+
+			if tokenInfo.Refresh_token != "" {
+				entry.RefreshToken = tokenInfo.Refresh_token
+			}
+
+		}
+
+	}
+
 	//Store it
 	jsonEntry, err := logical.StorageEntryJSON(CredentialsRootPath+name, entry)
 	if err != nil {
@@ -242,7 +272,7 @@ func (b *backend) getVenafiSecret(ctx context.Context, s logical.Storage, name s
 }
 
 func validateVenafiSecretEntry(entry *venafiSecretEntry) error {
-	if !entry.Fakemode && entry.Apikey == "" && (entry.TppUser == "" || entry.TppPassword == "") && entry.AccessToken == "" {
+	if !entry.Fakemode && entry.Apikey == "" && (entry.TppUser == "" || entry.TppPassword == "") && entry.RefreshToken == "" && entry.AccessToken == "" {
 		return fmt.Errorf(errorTextInvalidMode)
 	}
 

--- a/plugin/pki/util.go
+++ b/plugin/pki/util.go
@@ -402,22 +402,22 @@ func createConfigFromFieldData(data *venafiSecretEntry) (*vcert.Config, error) {
 
 func getAccessData(cfg *vcert.Config) (tpp.OauthRefreshAccessTokenResponse, error) {
 
-	var tookenInfoResponse tpp.OauthRefreshAccessTokenResponse
+	var tokenInfoResponse tpp.OauthRefreshAccessTokenResponse
 	tppConnector, _ := getTppConnector(cfg)
 	httpClient, err := getHTTPClient(cfg.ConnectionTrust)
 
 	if err != nil {
-		return tookenInfoResponse, err
+		return tokenInfoResponse, err
 	}
 
 	tppConnector.SetHTTPClient(httpClient)
 
-	tookenInfoResponse, err = tppConnector.RefreshAccessToken(&endpoint.Authentication{
+	tokenInfoResponse, err = tppConnector.RefreshAccessToken(&endpoint.Authentication{
 		RefreshToken: cfg.Credentials.RefreshToken,
 		ClientId:     "hashicorp-vault-by-venafi",
 		Scope:        "certificate:manage,revoke",
 	})
 
-	return tookenInfoResponse, err
+	return tokenInfoResponse, err
 
 }

--- a/plugin/pki/util.go
+++ b/plugin/pki/util.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
 	"github.com/Venafi/vcert/v4/pkg/venafi/tpp"
 	"github.com/hashicorp/vault/sdk/logical"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -22,6 +23,7 @@ import (
 const (
 	role_ttl_test_property = int(120)
 	ttl_test_property      = int(48)
+	HTTP_UNAUTHORIZED = 401
 )
 
 func sliceContains(slice []string, item string) bool {
@@ -336,4 +338,86 @@ func copyMap(m map[string]interface{}) map[string]interface{} {
 	}
 
 	return cp
+}
+
+
+func getStatusCode(msg string) int64 {
+
+	var statusCode int64
+	splittedMsg := strings.Split(msg, ":")
+
+	for i := 0; i < len(splittedMsg); i++ {
+
+		current := splittedMsg[i]
+		current = strings.TrimSpace(current)
+
+		if current == "Invalid status" {
+
+			status := splittedMsg[i+1]
+			status = strings.TrimSpace(status)
+			splittedStatus := strings.Split(status, " ")
+			statusCode, _ = strconv.ParseInt(splittedStatus[0], 10, 64)
+			break
+
+		}
+	}
+
+	return statusCode
+}
+
+func createConfigFromFieldData(data *venafiSecretEntry) (*vcert.Config, error) {
+
+	var cfg *vcert.Config
+	cfg = &vcert.Config{}
+
+	cfg.BaseUrl = data.URL
+	cfg.Zone = data.Zone
+	cfg.LogVerbose = true
+
+	trustBundlePath := data.TrustBundleFile
+
+	if trustBundlePath != "" {
+
+		var trustBundlePEM string
+		trustBundle, err := ioutil.ReadFile(trustBundlePath)
+
+		if err != nil {
+			return cfg, err
+		}
+
+		trustBundlePEM = string(trustBundle)
+		cfg.ConnectionTrust = trustBundlePEM
+	}
+
+	cfg.ConnectorType = endpoint.ConnectorTypeTPP
+
+	cfg.Credentials = &endpoint.Authentication{
+
+		AccessToken:  data.AccessToken,
+		RefreshToken: data.RefreshToken,
+	}
+
+	return cfg, nil
+}
+
+func getAccessData(cfg *vcert.Config) (tpp.OauthRefreshAccessTokenResponse, error) {
+
+	var tookenInfoResponse tpp.OauthRefreshAccessTokenResponse
+	tppConnector, _ := getTppConnector(cfg)
+	httpClient, err := getHTTPClient(cfg.ConnectionTrust)
+
+	if err != nil {
+		return tookenInfoResponse, err
+	}
+
+	tppConnector.SetHTTPClient(httpClient)
+
+	tookenInfoResponse, err = tppConnector.RefreshAccessToken(&endpoint.Authentication{
+		RefreshToken: cfg.Credentials.RefreshToken,
+		ClientId:     "hashicorp-vault-by-venafi",
+		Scope:        "certificate:manage,revoke",
+	})
+
+	return tookenInfoResponse, err
+
 }


### PR DESCRIPTION
now user can include just a refresh token when creating a venafi secret, then the refresh token will be used and then get a new access token and refresh token.

also as latest version of tpp(20.4) the error expired_token is not longer being thrown, so removing that validation and adding a validation for http code 401, this will be thrown when access token is expired or is invalid.

all test suite ran welll