### PR TITLE
Fix for issue #75

### DIFF
--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -336,31 +336,25 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request
 
 	}
 
-	issuing_ca := ""
+	issuingCA := ""
 	if len(pcc.Chain) > 0 {
-		issuing_ca = pcc.Chain[0]
+		issuingCA = pcc.Chain[0]
 	}
 
-	var respData map[string]interface{}
+	expirationTime := parsedCertificate.NotAfter
+	expirationSec := expirationTime.Unix()
+
+	respData := map[string]interface{}{
+		"common_name":       reqData.commonName,
+		"serial_number":     serialNumber,
+		"certificate_chain": chain,
+		"certificate":       pcc.Certificate,
+		"ca_chain":          pcc.Chain,
+		"issuing_ca":        issuingCA,
+		"expiration":        expirationSec,
+	}
 	if !signCSR {
-		respData = map[string]interface{}{
-			"common_name":       reqData.commonName,
-			"serial_number":     serialNumber,
-			"certificate_chain": chain,
-			"certificate":       pcc.Certificate,
-			"private_key":       pcc.PrivateKey,
-			"ca_chain":          pcc.Chain,
-			"issuing_ca":        issuing_ca,
-		}
-	} else {
-		respData = map[string]interface{}{
-			"common_name":       reqData.commonName,
-			"serial_number":     serialNumber,
-			"certificate_chain": chain,
-			"certificate":       pcc.Certificate,
-			"ca_chain":          pcc.Chain,
-			"issuing_ca":        issuing_ca,
-		}
+		respData["private_key"] = pcc.PrivateKey
 	}
 
 	var logResp *logical.Response

--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -285,6 +285,7 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request
 
 	var entry *logical.StorageEntry
 	chain := strings.Join(append([]string{pcc.Certificate}, pcc.Chain...), "\n")
+	b.Logger().Debug("cert Chain: " + strings.Join(pcc.Chain, ", "))
 
 	if !signCSR {
 		err = pcc.AddPrivateKey(certReq.PrivateKey, []byte(data.Get("key_password").(string)))
@@ -335,6 +336,11 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request
 
 	}
 
+	issuing_ca := ""
+	if len(pcc.Chain) > 0 {
+		issuing_ca = pcc.Chain[0]
+	}
+
 	var respData map[string]interface{}
 	if !signCSR {
 		respData = map[string]interface{}{
@@ -343,6 +349,8 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request
 			"certificate_chain": chain,
 			"certificate":       pcc.Certificate,
 			"private_key":       pcc.PrivateKey,
+			"ca_chain":          pcc.Chain,
+			"issuing_ca":        issuing_ca,
 		}
 	} else {
 		respData = map[string]interface{}{
@@ -350,6 +358,8 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request
 			"serial_number":     serialNumber,
 			"certificate_chain": chain,
 			"certificate":       pcc.Certificate,
+			"ca_chain":          pcc.Chain,
+			"issuing_ca":        issuing_ca,
 		}
 	}
 


### PR DESCRIPTION
Updated enroll and sign operations to return a structure compatible with native vault pki output.
Added issuer_ca and ca_chain fields to the enroll and sign certificate outputs