### PR TITLE
Refresh token is failing when trust bundle is not provided.

### DIFF
--- a/plugin/pki/util.go
+++ b/plugin/pki/util.go
@@ -286,6 +286,13 @@ func getHTTPClient(trustBundlePem string) (*http.Client, error) {
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 	tlsConfig := http.DefaultTransport.(*http.Transport).TLSClientConfig
+
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	} else {
+		tlsConfig = tlsConfig.Clone()
+	}
+
 	/* #nosec */
 	if trustBundlePem != "" {
 		trustBundle, err := parseTrustBundlePEM(trustBundlePem)
@@ -293,11 +300,6 @@ func getHTTPClient(trustBundlePem string) (*http.Client, error) {
 			return nil, err
 		}
 
-		if tlsConfig == nil {
-			tlsConfig = &tls.Config{}
-		} else {
-			tlsConfig = tlsConfig.Clone()
-		}
 		tlsConfig.RootCAs = trustBundle
 	}
 


### PR DESCRIPTION
**Issue:** when creating a venafi-secret and specifying a refresh token but not trust bundle, the creating process will fail.
**Origin of the issue:** Tls config is null when getting a http client on refresh token process, since tls config is created only when trust bundle is provided.

**Fix for the issue:** Extract validation against null and initialization for tls config when getting http client 


**All test cases ran well**