### PR TITLE
Fix Issue with revocation while disabling secrets engine

### DIFF
--- a/plugin/pki/path_venafi_cert_revoke.go
+++ b/plugin/pki/path_venafi_cert_revoke.go
@@ -38,6 +38,11 @@ func pathVenafiCertRevoke(b *backend) *framework.Path {
 
 func (b *backend) venafiCertRevoke(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 
+	op := req.Operation
+	if op == logical.RevokeOperation {
+		return nil, nil
+	}
+
 	b.Logger().Debug("Getting the role\n")
 	roleName := d.Get("role").(string)
 


### PR DESCRIPTION
Adds verification of context operation so if revocation is called by vault while disabling Secrets engine no action is taken