### PR TITLE
feat: introduce custom client id

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ Venafi secrets engine:
    other available options for the Venafi secret after it is created, use
    `vault path-help venafi-pki/venafi/:name`.
 
+    :pushpin: **NOTE**: When obtaining a `access_token` and `refresh_token` from
+    Trust Protection Platform, make sure you use the same _client id_ when
+    configuring the Venafi secret in Vault. Default the `client_id` is set to
+    "hashicorp-vault-by-venafi".
+
    **Trust Protection Platform**:
 
    ```

--- a/plugin/pki/path_venafi_secrets.go
+++ b/plugin/pki/path_venafi_secrets.go
@@ -86,6 +86,11 @@ Example: trust_bundle_file="/path-to/bundle.pem""`,
 				Description: `Set it to true to use fake CA instead of Cloud or Platform to issue certificates. Useful for testing.`,
 				Default:     false,
 			},
+			"client_id": {
+				Type:        framework.TypeString,
+				Description: `Use to specify the application that will be using the token.`,
+				Default:     `hashicorp-vault-by-venafi`,
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
@@ -188,6 +193,7 @@ func (b *backend) pathVenafiSecretCreate(ctx context.Context, req *logical.Reque
 		Apikey:          data.Get("apikey").(string),
 		TrustBundleFile: data.Get("trust_bundle_file").(string),
 		Fakemode:        data.Get("fakemode").(bool),
+		ClientId:        data.Get("client_id").(string),
 	}
 
 	err = validateVenafiSecretEntry(entry)
@@ -337,6 +343,7 @@ type venafiSecretEntry struct {
 	Apikey          string `json:"apikey"`
 	TrustBundleFile string `json:"trust_bundle_file"`
 	Fakemode        bool   `json:"fakemode"`
+	ClientId        string `json:"client_id"`
 }
 
 func (p *venafiSecretEntry) ToResponseData() map[string]interface{} {
@@ -353,6 +360,7 @@ func (p *venafiSecretEntry) ToResponseData() map[string]interface{} {
 		"apikey":            p.getStringMask(),
 		"trust_bundle_file": p.TrustBundleFile,
 		"fakemode":          p.Fakemode,
+		"client_id":         p.ClientId,
 	}
 	return responseData
 }

--- a/plugin/pki/util.go
+++ b/plugin/pki/util.go
@@ -100,6 +100,7 @@ type RunContext struct {
 	TPPIssuerCN         string
 	CloudIssuerCN       string
 	FakeIssuerCN        string
+	ClientId            string
 }
 
 func GetContext() *RunContext {
@@ -117,6 +118,7 @@ func GetContext() *RunContext {
 
 	c.TokenUrl = os.Getenv("TPP_TOKEN_URL")
 	c.AccessToken = os.Getenv("ACCESS_TOKEN")
+	c.ClientId = os.Getenv("TPP_CLIENT_ID")
 
 	c.TPPTestingEnabled, _ = strconv.ParseBool(os.Getenv("VENAFI_TPP_TESTING"))
 	c.CloudTestingEnabled, _ = strconv.ParseBool(os.Getenv("VENAFI_CLOUD_TESTING"))
@@ -253,7 +255,7 @@ func updateAccessToken(cfg *vcert.Config, b *backend, ctx context.Context, req *
 
 	resp, err := tppConnector.RefreshAccessToken(&endpoint.Authentication{
 		RefreshToken: cfg.Credentials.RefreshToken,
-		ClientId:     "hashicorp-vault-by-venafi",
+		ClientId:     cfg.Credentials.ClientId,
 		Scope:        "certificate:manage,revoke",
 	})
 	if resp.Access_token != "" && resp.Refresh_token != "" {
@@ -424,6 +426,7 @@ func createConfigFromFieldData(data *venafiSecretEntry) (*vcert.Config, error) {
 
 		AccessToken:  data.AccessToken,
 		RefreshToken: data.RefreshToken,
+		ClientId:     data.ClientId,
 	}
 
 	return cfg, nil
@@ -443,7 +446,7 @@ func getAccessData(cfg *vcert.Config) (tpp.OauthRefreshAccessTokenResponse, erro
 
 	tokenInfoResponse, err = tppConnector.RefreshAccessToken(&endpoint.Authentication{
 		RefreshToken: cfg.Credentials.RefreshToken,
-		ClientId:     "hashicorp-vault-by-venafi",
+		ClientId:     cfg.Credentials.ClientId,
 		Scope:        "certificate:manage,revoke",
 	})
 


### PR DESCRIPTION
Make it possible to set a custom client id when configuring Venafi in Vault.