### PR TITLE
Busted cache. Adds default value for minimum cert validity

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,9 +348,10 @@ possibly erroneous results.
 In order to prevent an issuance of a new certificate if current certificate exists in Vault's storage, we added a capability
 to return that certificate instead. To issue this feature you must set:
 
-- `min_cert_time_left`: Golang's duration format string (e.g. 24h, 23h5m20s, 10000s, etc.)
-- `store_by="serial"`
-- `store_pkey=true`
+- `min_cert_time_left` (_optional_): Golang's duration format string (e.g. 24h, 23h5m20s, 10000s, etc.). Default is 30 days.
+- `store_by="serial"` (_required_)
+- `store_pkey=true` (_required_)
+- `no_cache=false`  (_required_)
 
 If certificate was successfully loaded from Vault storage, you will encounter `Loading certificate from storage` message
 in logs when `[DEBUG]` mode is set:
@@ -385,11 +386,12 @@ It's required to set any of (at least one): `Common Name` or `SAN DNS`.
 In order to prevent an issuance of a new certificate if current certificate exists in Vault's storage, we added a capability
 to return that certificate instead. To issue this feature you must set:
 
-- `min_cert_time_left`: Golang's duration format string (e.g. 24h, 23h5m20s, 10000s, etc.)
-- `store_by="hash"`
-- `store_pkey=true`
+- `min_cert_time_left` (_optional_): Golang's duration format string (e.g. 24h, 23h5m20s, 10000s, etc.). Default is 30 days.
+- `store_by="hash"` (_required_)
+- `store_pkey=true` (_required_)
+- `no_cache=false` (_required_)
 
-If certificate was successfully loaded from Vault storage, you will encounter `Loading certificate from storage` message
+`If certificate was successfully loaded from Vault storage, you will encounter `Loading certificate from storage` message
 in logs when `[DEBUG]` mode is set:
 
 ```
@@ -405,6 +407,11 @@ C1ZlbmFmaSBJbmMuMRQwEgYDVQQLEwtFbmdpbmVlcmluZzEbMBkGA1UECxMSUHJv
 ZHVjdCBNYW5hZ2VtZW50MRowGAYDVQQLExFRdWFsaXR5IEFzc3VyYW5jZTEkMCIG
 A1UEAxMbbm9wcml2YXRla2V5LnZlbmFmaS5leGFtcGxlMIIBIjANBgkqhkiG9w0B
 ```
+
+## Bursted Cache
+
+We introduced a new attribute `no_cache` for role parameter to completely turn off any prevent re-issuance feature.
+Default is turned off with value `false`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,6 @@ to return that certificate instead. To issue this feature you must set:
 - `min_cert_time_left` (_optional_): Golang's duration format string (e.g. 24h, 23h5m20s, 10000s, etc.). Default is 30 days.
 - `store_by="serial"` (_required_)
 - `store_pkey=true` (_required_)
-- `ignore_local_storage=false`  (_required_)
 
 If certificate was successfully loaded from Vault storage, you will encounter `Loading certificate from storage` message
 in logs when `[DEBUG]` mode is set:
@@ -389,7 +388,6 @@ to return that certificate instead. To issue this feature you must set:
 - `min_cert_time_left` (_optional_): Golang's duration format string (e.g. 24h, 23h5m20s, 10000s, etc.). Default is 30 days.
 - `store_by="hash"` (_required_)
 - `store_pkey=true` (_required_)
-- `ignore_local_storage=false` (_required_)
 
 If certificate was successfully loaded from Vault storage, you will encounter `Loading certificate from storage` message
 in logs when `[DEBUG]` mode is set:

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ to return that certificate instead. To issue this feature you must set:
 - `store_pkey=true` (_required_)
 - `ignore_local_storage=false` (_required_)
 
-`If certificate was successfully loaded from Vault storage, you will encounter `Loading certificate from storage` message
+If certificate was successfully loaded from Vault storage, you will encounter `Loading certificate from storage` message
 in logs when `[DEBUG]` mode is set:
 
 ```

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ to return that certificate instead. To issue this feature you must set:
 - `min_cert_time_left` (_optional_): Golang's duration format string (e.g. 24h, 23h5m20s, 10000s, etc.). Default is 30 days.
 - `store_by="serial"` (_required_)
 - `store_pkey=true` (_required_)
-- `no_cache=false`  (_required_)
+- `ignore_local_storage=false`  (_required_)
 
 If certificate was successfully loaded from Vault storage, you will encounter `Loading certificate from storage` message
 in logs when `[DEBUG]` mode is set:
@@ -389,7 +389,7 @@ to return that certificate instead. To issue this feature you must set:
 - `min_cert_time_left` (_optional_): Golang's duration format string (e.g. 24h, 23h5m20s, 10000s, etc.). Default is 30 days.
 - `store_by="hash"` (_required_)
 - `store_pkey=true` (_required_)
-- `no_cache=false` (_required_)
+- `ignore_local_storage=false` (_required_)
 
 `If certificate was successfully loaded from Vault storage, you will encounter `Loading certificate from storage` message
 in logs when `[DEBUG]` mode is set:
@@ -408,10 +408,11 @@ ZHVjdCBNYW5hZ2VtZW50MRowGAYDVQQLExFRdWFsaXR5IEFzc3VyYW5jZTEkMCIG
 A1UEAxMbbm9wcml2YXRla2V5LnZlbmFmaS5leGFtcGxlMIIBIjANBgkqhkiG9w0B
 ```
 
-## Bursted Cache
+## Ignore Local Storage
 
-We introduced a new attribute `no_cache` for role parameter to completely turn off any prevent re-issuance feature.
-Default is turned off with value `false`.
+If certificates are stored locally in vault by `serial` or `hash`, normal behavior would be to always look into certificate locally before issuing a new certificate.
+If `ignore_local_storage` flag is set to `true`, it would bypass the logic to check certificate locally (to prevent re-issue) and always issue a new certificate.
+Default value is always `false`.
 
 ## License
 

--- a/plugin/pki/backend_test.go
+++ b/plugin/pki/backend_test.go
@@ -183,7 +183,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuance(t, data, venafiConfigToken)
@@ -195,7 +194,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceCNwithExtraSANDNS(t, data, venafiConfigToken)
@@ -207,7 +205,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceCNandRemovingSANDNS(t, data, venafiConfigToken)
@@ -219,7 +216,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceCNnoSANSDNS(t, data, venafiConfigToken)
@@ -232,7 +228,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 				t.Fatal(err)
 			}
 			data := testData{
-				noCache:         false,
 				minCertTimeLeft: time.Duration(24) * time.Hour,
 				ttl:             time.Duration(23) * time.Hour,
 			}
@@ -246,7 +241,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 		}
 		// we set a TLL less than a time we consider a certificate to be valid, so we always issue a new one
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: time.Duration(24) * time.Hour,
 			ttl:             time.Duration(25) * time.Hour,
 		}
@@ -259,7 +253,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceCNwithThreeSANDNS(t, data, venafiConfigToken)
@@ -271,7 +264,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceCNwithDifferentCNandThreeSANDNS(t, data, venafiConfigToken)
@@ -283,7 +275,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceCNwithNoCNandThreeSANDNS(t, data, venafiConfigToken)
@@ -297,7 +288,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 		}
 		data := testData{
 			serviceGeneratedCert: true,
-			noCache:              false,
 			minCertTimeLeft:      regDuration,
 		}
 		integrationTestEnv.PreventReissuance(t, data, venafiConfigToken)
@@ -324,7 +314,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNandRemovingSANDNS(t, data, venafiConfigToken)
@@ -338,7 +327,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNnoSANSDNS(t, data, venafiConfigToken)
@@ -352,7 +340,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      time.Duration(24) * time.Hour,
 				ttl:                  time.Duration(23) * time.Hour,
 			}
@@ -367,7 +354,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      time.Duration(24) * time.Hour,
 				ttl:                  time.Duration(25) * time.Hour,
 			}
@@ -382,7 +368,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNwithThreeSANDNS(t, data, venafiConfigToken)
@@ -396,7 +381,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNwithDifferentCNandThreeSANDNS(t, data, venafiConfigToken)
@@ -410,7 +394,6 @@ func TestTPPpreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNwithNoCNandThreeSANDNS(t, data, venafiConfigToken)
@@ -454,7 +437,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuance(t, data, venafiConfigCloud)
@@ -466,7 +448,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceCNwithExtraSANDNS(t, data, venafiConfigCloud)
@@ -478,7 +459,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceCNandRemovingSANDNS(t, data, venafiConfigCloud)
@@ -490,7 +470,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceCNnoSANSDNS(t, data, venafiConfigCloud)
@@ -502,7 +481,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 				t.Fatal(err)
 			}
 			data := testData{
-				noCache: false,
 				// for VaaS use case we need to set and extra 24 hours since value is truncated (2184hrs = 91 days)
 				minCertTimeLeft: time.Duration(2184) * time.Hour,
 			}
@@ -515,7 +493,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: time.Duration(2159) * time.Hour,
 		}
 		integrationTestEnv.PreventReissuanceTTLvalid(t, data, venafiConfigCloud)
@@ -527,7 +504,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceCNwithThreeSANDNS(t, data, venafiConfigCloud)
@@ -539,7 +515,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceCNwithDifferentCNandThreeSANDNS(t, data, venafiConfigCloud)
@@ -551,7 +526,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceCNwithNoCNandThreeSANDNS(t, data, venafiConfigCloud)
@@ -565,7 +539,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 		}
 		data := testData{
 			serviceGeneratedCert: true,
-			noCache:              false,
 			minCertTimeLeft:      regDuration,
 		}
 		integrationTestEnv.PreventReissuance(t, data, venafiConfigCloud)
@@ -579,7 +552,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNwithExtraSANDNS(t, data, venafiConfigCloud)
@@ -593,7 +565,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNandRemovingSANDNS(t, data, venafiConfigCloud)
@@ -607,7 +578,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNnoSANSDNS(t, data, venafiConfigCloud)
@@ -620,7 +590,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				// for VaaS use case we need to set and extra 24 hours since value is truncated (2184hrs = 91 days)
 				minCertTimeLeft: time.Duration(2184) * time.Hour,
 			}
@@ -635,7 +604,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      time.Duration(2159) * time.Hour,
 			}
 			integrationTestEnv.PreventReissuanceTTLvalid(t, data, venafiConfigCloud)
@@ -649,7 +617,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNwithThreeSANDNS(t, data, venafiConfigCloud)
@@ -663,7 +630,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNwithDifferentCNandThreeSANDNS(t, data, venafiConfigCloud)
@@ -678,7 +644,6 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNwithNoCNandThreeSANDNS(t, data, venafiConfigCloud)
@@ -695,7 +660,6 @@ func TestTPPpreventLocal(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceLocal(t, data, venafiConfigToken)
@@ -707,7 +671,6 @@ func TestTPPpreventLocal(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceLocalCNwithExtraSANDNS(t, data, venafiConfigToken)
@@ -719,7 +682,6 @@ func TestTPPpreventLocal(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceLocalCNandRemovingSANDNS(t, data, venafiConfigToken)
@@ -731,7 +693,6 @@ func TestTPPpreventLocal(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceLocalCNandNoSANSDNS(t, data, venafiConfigToken)
@@ -744,7 +705,6 @@ func TestTPPpreventLocal(t *testing.T) {
 				t.Fatal(err)
 			}
 			data := testData{
-				noCache:         false,
 				minCertTimeLeft: time.Duration(24) * time.Hour,
 				ttl:             time.Duration(23) * time.Hour,
 			}
@@ -758,7 +718,6 @@ func TestTPPpreventLocal(t *testing.T) {
 		}
 		// we set a TLL less than a time we consider a certificate to be valid, so we always issue a new one
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: time.Duration(24) * time.Hour,
 			ttl:             time.Duration(25) * time.Hour,
 		}
@@ -771,7 +730,6 @@ func TestTPPpreventLocal(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceLocalCNwithThreeSANDNS(t, data, venafiConfigToken)
@@ -783,7 +741,6 @@ func TestTPPpreventLocal(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceLocalCNwithDifferentCNandThreeSANDNS(t, data, venafiConfigToken)
@@ -795,7 +752,6 @@ func TestTPPpreventLocal(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         false,
 			minCertTimeLeft: regDuration,
 		}
 		integrationTestEnv.PreventReissuanceLocalCNwithNoCNandThreeSANDNS(t, data, venafiConfigToken)
@@ -809,7 +765,6 @@ func TestTPPpreventLocal(t *testing.T) {
 		}
 		data := testData{
 			serviceGeneratedCert: true,
-			noCache:              false,
 			minCertTimeLeft:      regDuration,
 		}
 		integrationTestEnv.PreventReissuanceLocal(t, data, venafiConfigToken)
@@ -823,7 +778,6 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceLocalCNwithExtraSANDNS(t, data, venafiConfigToken)
@@ -837,7 +791,6 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceLocalCNandRemovingSANDNS(t, data, venafiConfigToken)
@@ -851,7 +804,6 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceLocalCNandNoSANSDNS(t, data, venafiConfigToken)
@@ -865,7 +817,6 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      time.Duration(24) * time.Hour,
 				ttl:                  time.Duration(23) * time.Hour,
 			}
@@ -880,7 +831,6 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      time.Duration(24) * time.Hour,
 				ttl:                  time.Duration(25) * time.Hour,
 			}
@@ -895,7 +845,6 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceLocalCNwithThreeSANDNS(t, data, venafiConfigToken)
@@ -909,7 +858,6 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceLocalCNwithDifferentCNandThreeSANDNS(t, data, venafiConfigToken)
@@ -923,7 +871,6 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
-				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceLocalCNwithNoCNandThreeSANDNS(t, data, venafiConfigToken)

--- a/plugin/pki/backend_test.go
+++ b/plugin/pki/backend_test.go
@@ -407,7 +407,7 @@ func TestTPPpreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache: false,
+			ignoreLocalStorage: false,
 		}
 		integrationTestEnv.PreventReissuance(t, data, venafiConfigToken)
 	})
@@ -420,8 +420,8 @@ func TestTPPpreventReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         true,
-			minCertTimeLeft: regDuration,
+			ignoreLocalStorage: true,
+			minCertTimeLeft:    regDuration,
 		}
 		integrationTestEnv.NotPreventReissuance(t, data, venafiConfigToken)
 	})
@@ -1091,7 +1091,7 @@ func TestVaasPreventLocalReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache: false,
+			ignoreLocalStorage: false,
 		}
 		integrationTestEnv.PreventReissuanceLocal(t, data, venafiConfigToken)
 	})
@@ -1104,8 +1104,8 @@ func TestVaasPreventLocalReissuance(t *testing.T) {
 			t.Fatal(err)
 		}
 		data := testData{
-			noCache:         true,
-			minCertTimeLeft: regDuration,
+			ignoreLocalStorage: true,
+			minCertTimeLeft:    regDuration,
 		}
 		integrationTestEnv.NotPreventReissuanceLocal(t, data, venafiConfigToken)
 	})

--- a/plugin/pki/backend_test.go
+++ b/plugin/pki/backend_test.go
@@ -182,7 +182,10 @@ func TestTPPpreventReissuance(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuance(t, data, venafiConfigToken)
 	})
 	// CASE: should be different - same CN but 1 additional SAN
@@ -191,7 +194,10 @@ func TestTPPpreventReissuance(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceCNwithExtraSANDNS(t, data, venafiConfigToken)
 	})
 	// CASE: should be different - same CN and missing 1 SAN of 3
@@ -200,7 +206,10 @@ func TestTPPpreventReissuance(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceCNandRemovingSANDNS(t, data, venafiConfigToken)
 	})
 	// CASE: should be the SAME - same CN and no SANs
@@ -209,7 +218,10 @@ func TestTPPpreventReissuance(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceCNnoSANSDNS(t, data, venafiConfigToken)
 	})
 	// CASE: should be different - same CN and SAN but just barely not sufficiently valid
@@ -220,6 +232,7 @@ func TestTPPpreventReissuance(t *testing.T) {
 				t.Fatal(err)
 			}
 			data := testData{
+				noCache:         false,
 				minCertTimeLeft: time.Duration(24) * time.Hour,
 				ttl:             time.Duration(23) * time.Hour,
 			}
@@ -233,6 +246,7 @@ func TestTPPpreventReissuance(t *testing.T) {
 		}
 		// we set a TLL less than a time we consider a certificate to be valid, so we always issue a new one
 		data := testData{
+			noCache:         false,
 			minCertTimeLeft: time.Duration(24) * time.Hour,
 			ttl:             time.Duration(25) * time.Hour,
 		}
@@ -244,7 +258,10 @@ func TestTPPpreventReissuance(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceCNwithThreeSANDNS(t, data, venafiConfigToken)
 	})
 	// CASE: should be different - different CN and same 3 SANs
@@ -253,7 +270,10 @@ func TestTPPpreventReissuance(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceCNwithDifferentCNandThreeSANDNS(t, data, venafiConfigToken)
 	})
 	// CASE: should be the SAME - no CN and same 3 SANs
@@ -262,7 +282,10 @@ func TestTPPpreventReissuance(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceCNwithNoCNandThreeSANDNS(t, data, venafiConfigToken)
 	})
 	// Service generated CSR
@@ -274,6 +297,7 @@ func TestTPPpreventReissuance(t *testing.T) {
 		}
 		data := testData{
 			serviceGeneratedCert: true,
+			noCache:              false,
 			minCertTimeLeft:      regDuration,
 		}
 		integrationTestEnv.PreventReissuance(t, data, venafiConfigToken)
@@ -300,6 +324,7 @@ func TestTPPpreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNandRemovingSANDNS(t, data, venafiConfigToken)
@@ -313,6 +338,7 @@ func TestTPPpreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNnoSANSDNS(t, data, venafiConfigToken)
@@ -326,6 +352,7 @@ func TestTPPpreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      time.Duration(24) * time.Hour,
 				ttl:                  time.Duration(23) * time.Hour,
 			}
@@ -340,6 +367,7 @@ func TestTPPpreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      time.Duration(24) * time.Hour,
 				ttl:                  time.Duration(25) * time.Hour,
 			}
@@ -354,6 +382,7 @@ func TestTPPpreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNwithThreeSANDNS(t, data, venafiConfigToken)
@@ -367,6 +396,7 @@ func TestTPPpreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNwithDifferentCNandThreeSANDNS(t, data, venafiConfigToken)
@@ -380,10 +410,38 @@ func TestTPPpreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNwithNoCNandThreeSANDNS(t, data, venafiConfigToken)
 		})
+
+	// CASE: should be the SAME - same CN and SAN
+	// no cert time left set in roll, role's cert minimum time left defaults to 30 days, should still be valid on next validation
+	t.Run("TPP Token enroll same certificate and prevent-reissue - no min time specified", func(t *testing.T) {
+		integrationTestEnv, err := newIntegrationTestEnv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		data := testData{
+			noCache: false,
+		}
+		integrationTestEnv.PreventReissuance(t, data, venafiConfigToken)
+	})
+
+	// CASE: should be the SAME - same CN and SAN
+	// turn off prevent-reissue, we specify certificate's minimum time left but still should not prevent reissue
+	t.Run("TPP Token enroll same certificate and should not prevent-reissue - cache turned off - min time specified", func(t *testing.T) {
+		integrationTestEnv, err := newIntegrationTestEnv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		data := testData{
+			noCache:         true,
+			minCertTimeLeft: regDuration,
+		}
+		integrationTestEnv.NotPreventReissuance(t, data, venafiConfigToken)
+	})
 }
 
 func TestVaasPreventReissuance(t *testing.T) {
@@ -395,7 +453,10 @@ func TestVaasPreventReissuance(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuance(t, data, venafiConfigCloud)
 	})
 	// CASE: should be different - same CN but 1 additional SAN
@@ -404,7 +465,10 @@ func TestVaasPreventReissuance(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceCNwithExtraSANDNS(t, data, venafiConfigCloud)
 	})
 	// CASE: should be different - same CN and missing 1 SAN of 3
@@ -413,7 +477,10 @@ func TestVaasPreventReissuance(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceCNandRemovingSANDNS(t, data, venafiConfigCloud)
 	})
 	// CASE: should be the SAME - same CN and no SANs
@@ -422,7 +489,10 @@ func TestVaasPreventReissuance(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceCNnoSANSDNS(t, data, venafiConfigCloud)
 	})
 	t.Run("VaaS second enroll same certificate with TTL that is not sufficient for set valid time and should not prevent-reissue",
@@ -432,6 +502,7 @@ func TestVaasPreventReissuance(t *testing.T) {
 				t.Fatal(err)
 			}
 			data := testData{
+				noCache: false,
 				// for VaaS use case we need to set and extra 24 hours since value is truncated (2184hrs = 91 days)
 				minCertTimeLeft: time.Duration(2184) * time.Hour,
 			}
@@ -443,7 +514,10 @@ func TestVaasPreventReissuance(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: time.Duration(2159) * time.Hour}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: time.Duration(2159) * time.Hour,
+		}
 		integrationTestEnv.PreventReissuanceTTLvalid(t, data, venafiConfigCloud)
 	})
 	// CASE: should be the SAME - same CN and same 3 SANs
@@ -452,7 +526,10 @@ func TestVaasPreventReissuance(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceCNwithThreeSANDNS(t, data, venafiConfigCloud)
 	})
 	// CASE: should be different - different CN and same 3 SANs
@@ -461,7 +538,10 @@ func TestVaasPreventReissuance(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceCNwithDifferentCNandThreeSANDNS(t, data, venafiConfigCloud)
 	})
 	// CASE: should be the SAME - no CN and same 3 SANs
@@ -470,7 +550,10 @@ func TestVaasPreventReissuance(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceCNwithNoCNandThreeSANDNS(t, data, venafiConfigCloud)
 	})
 	// Service generated CSR
@@ -482,6 +565,7 @@ func TestVaasPreventReissuance(t *testing.T) {
 		}
 		data := testData{
 			serviceGeneratedCert: true,
+			noCache:              false,
 			minCertTimeLeft:      regDuration,
 		}
 		integrationTestEnv.PreventReissuance(t, data, venafiConfigCloud)
@@ -495,6 +579,7 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNwithExtraSANDNS(t, data, venafiConfigCloud)
@@ -508,6 +593,7 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNandRemovingSANDNS(t, data, venafiConfigCloud)
@@ -521,6 +607,7 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNnoSANSDNS(t, data, venafiConfigCloud)
@@ -533,6 +620,7 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				// for VaaS use case we need to set and extra 24 hours since value is truncated (2184hrs = 91 days)
 				minCertTimeLeft: time.Duration(2184) * time.Hour,
 			}
@@ -547,6 +635,7 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      time.Duration(2159) * time.Hour,
 			}
 			integrationTestEnv.PreventReissuanceTTLvalid(t, data, venafiConfigCloud)
@@ -560,6 +649,7 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNwithThreeSANDNS(t, data, venafiConfigCloud)
@@ -573,6 +663,7 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNwithDifferentCNandThreeSANDNS(t, data, venafiConfigCloud)
@@ -587,6 +678,7 @@ func TestVaasPreventReissuance(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceCNwithNoCNandThreeSANDNS(t, data, venafiConfigCloud)
@@ -602,7 +694,10 @@ func TestTPPpreventLocal(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceLocal(t, data, venafiConfigToken)
 	})
 	// CASE: should be different - same CN but 1 additional SAN
@@ -611,7 +706,10 @@ func TestTPPpreventLocal(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceLocalCNwithExtraSANDNS(t, data, venafiConfigToken)
 	})
 	// CASE: should be different - same CN and missing 1 SAN of 3
@@ -620,7 +718,10 @@ func TestTPPpreventLocal(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceLocalCNandRemovingSANDNS(t, data, venafiConfigToken)
 	})
 	// CASE: should be the SAME - same CN and no SANs
@@ -629,7 +730,10 @@ func TestTPPpreventLocal(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceLocalCNandNoSANSDNS(t, data, venafiConfigToken)
 	})
 	// CASE: should be different - same CN and SAN but just barely not sufficiently valid
@@ -640,6 +744,7 @@ func TestTPPpreventLocal(t *testing.T) {
 				t.Fatal(err)
 			}
 			data := testData{
+				noCache:         false,
 				minCertTimeLeft: time.Duration(24) * time.Hour,
 				ttl:             time.Duration(23) * time.Hour,
 			}
@@ -653,6 +758,7 @@ func TestTPPpreventLocal(t *testing.T) {
 		}
 		// we set a TLL less than a time we consider a certificate to be valid, so we always issue a new one
 		data := testData{
+			noCache:         false,
 			minCertTimeLeft: time.Duration(24) * time.Hour,
 			ttl:             time.Duration(25) * time.Hour,
 		}
@@ -664,7 +770,10 @@ func TestTPPpreventLocal(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceLocalCNwithThreeSANDNS(t, data, venafiConfigToken)
 	})
 	// CASE: should be different - different CN and same 3 SANs
@@ -673,7 +782,10 @@ func TestTPPpreventLocal(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceLocalCNwithDifferentCNandThreeSANDNS(t, data, venafiConfigToken)
 	})
 	// CASE: should be the SAME - no CN and same 3 SANs
@@ -682,7 +794,10 @@ func TestTPPpreventLocal(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		data := testData{minCertTimeLeft: regDuration}
+		data := testData{
+			noCache:         false,
+			minCertTimeLeft: regDuration,
+		}
 		integrationTestEnv.PreventReissuanceLocalCNwithNoCNandThreeSANDNS(t, data, venafiConfigToken)
 	})
 	// Service generated CSR
@@ -694,6 +809,7 @@ func TestTPPpreventLocal(t *testing.T) {
 		}
 		data := testData{
 			serviceGeneratedCert: true,
+			noCache:              false,
 			minCertTimeLeft:      regDuration,
 		}
 		integrationTestEnv.PreventReissuanceLocal(t, data, venafiConfigToken)
@@ -707,6 +823,7 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceLocalCNwithExtraSANDNS(t, data, venafiConfigToken)
@@ -720,6 +837,7 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceLocalCNandRemovingSANDNS(t, data, venafiConfigToken)
@@ -733,6 +851,7 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceLocalCNandNoSANSDNS(t, data, venafiConfigToken)
@@ -746,6 +865,7 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      time.Duration(24) * time.Hour,
 				ttl:                  time.Duration(23) * time.Hour,
 			}
@@ -760,6 +880,7 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      time.Duration(24) * time.Hour,
 				ttl:                  time.Duration(25) * time.Hour,
 			}
@@ -774,6 +895,7 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceLocalCNwithThreeSANDNS(t, data, venafiConfigToken)
@@ -787,6 +909,7 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceLocalCNwithDifferentCNandThreeSANDNS(t, data, venafiConfigToken)
@@ -800,6 +923,7 @@ func TestTPPpreventLocal(t *testing.T) {
 			}
 			data := testData{
 				serviceGeneratedCert: true,
+				noCache:              false,
 				minCertTimeLeft:      regDuration,
 			}
 			integrationTestEnv.PreventReissuanceLocalCNwithNoCNandThreeSANDNS(t, data, venafiConfigToken)
@@ -1011,6 +1135,33 @@ func TestVaasPreventLocalReissuance(t *testing.T) {
 			}
 			integrationTestEnv.PreventReissuanceLocalCNwithNoCNandThreeSANDNS(t, data, venafiConfigCloud)
 		})
+
+	// CASE: should be the SAME - same CN and SAN
+	// no cert time left set in roll, role's cert minimum time left defaults to 30 days, should still be valid on next validation
+	t.Run("TPP Token enroll same certificate and prevent-reissue locally - no min time specified", func(t *testing.T) {
+		integrationTestEnv, err := newIntegrationTestEnv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		data := testData{
+			noCache: false,
+		}
+		integrationTestEnv.PreventReissuanceLocal(t, data, venafiConfigToken)
+	})
+
+	// CASE: should be the SAME - same CN and SAN
+	// turn off prevent-reissue-local, we specify certificate's minimum time left but still should not prevent reissue
+	t.Run("TPP Token enroll same certificate and should not prevent-reissue locally - cache turned off - min time specified", func(t *testing.T) {
+		integrationTestEnv, err := newIntegrationTestEnv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		data := testData{
+			noCache:         true,
+			minCertTimeLeft: regDuration,
+		}
+		integrationTestEnv.NotPreventReissuanceLocal(t, data, venafiConfigToken)
+	})
 }
 
 func TestZoneOverride(t *testing.T) {

--- a/plugin/pki/env_test.go
+++ b/plugin/pki/env_test.go
@@ -277,6 +277,13 @@ func (e *testEnv) writeRoleToBackendWithData(t *testing.T, configString venafiCo
 		roleData["store_by"] = data.storeBy
 	}
 
+	if &data.noCache != nil {
+		roleData["no_cache"] = data.noCache
+	} else {
+		// Default's
+		roleData["no_cache"] = false
+	}
+
 	if data.minCertTimeLeft > 0 {
 		roleData["min_cert_time_left"] = data.minCertTimeLeft
 	}

--- a/plugin/pki/env_test.go
+++ b/plugin/pki/env_test.go
@@ -57,7 +57,7 @@ type testData struct {
 	serviceGeneratedCert bool
 	privateKeyFormat     string
 	minCertTimeLeft      time.Duration
-	noCache              bool
+	ignoreLocalStorage   bool
 }
 
 const (
@@ -159,48 +159,49 @@ var venafiTestTokenConfigRestricted = map[string]interface{}{
 }
 
 var venafiTestFakeConfigDeprecatedStoreByCN = map[string]interface{}{
-	"generate_lease": true,
-	"store_by_cn":    true,
-	"store_pkey":     true,
-	"no_cache":       true,
+	"generate_lease":       true,
+	"store_by_cn":          true,
+	"store_pkey":           true,
+	"ignore_local_storage": true,
 }
 
 var venafiTestFakeConfigDeprecatedStoreBySerial = map[string]interface{}{
-	"generate_lease":  true,
-	"store_by_serial": true,
-	"store_pkey":      true,
-	"no_cache":        true,
+	"generate_lease":       true,
+	"store_by_serial":      true,
+	"store_pkey":           true,
+	"ignore_local_storage": true,
 }
 
 var venafiTestFakeConfigStoreByCN = map[string]interface{}{
-	"generate_lease": true,
-	"store_by":       "cn",
-	"store_pkey":     true,
+	"generate_lease":       true,
+	"store_by":             "cn",
+	"store_pkey":           true,
+	"ignore_local_storage": true,
 }
 
 var venafiTestFakeConfigStoreBySerial = map[string]interface{}{
-	"generate_lease": true,
-	"store_by":       "serial",
-	"store_pkey":     true,
-	"no_cache":       true,
+	"generate_lease":       true,
+	"store_by":             "serial",
+	"store_pkey":           true,
+	"ignore_local_storage": true,
 }
 
 var venafiTestFakeConfig = map[string]interface{}{
-	"generate_lease": true,
-	"store_pkey":     true,
-	"no_cache":       true,
+	"generate_lease":       true,
+	"store_pkey":           true,
+	"ignore_local_storage": true,
 }
 
 var venafiTestFakeConfigNoStore = map[string]interface{}{
-	"generate_lease": true,
-	"no_store":       true,
-	"no_cache":       true,
+	"generate_lease":       true,
+	"no_store":             true,
+	"ignore_local_storage": true,
 }
 
 var venafiTestFakeConfigNoStorePKey = map[string]interface{}{
-	"generate_lease": true,
-	"store_pkey":     false,
-	"no_cache":       true,
+	"generate_lease":       true,
+	"store_pkey":           false,
+	"ignore_local_storage": true,
 }
 
 var venafiTestMixedTppAndCloudConfig = map[string]interface{}{
@@ -283,11 +284,11 @@ func (e *testEnv) writeRoleToBackendWithData(t *testing.T, configString venafiCo
 		roleData["store_by"] = data.storeBy
 	}
 
-	if &data.noCache != nil {
-		roleData["no_cache"] = data.noCache
+	if &data.ignoreLocalStorage != nil {
+		roleData["ignore_local_storage"] = data.ignoreLocalStorage
 	} else {
 		// Default's
-		roleData["no_cache"] = false
+		roleData["ignore_local_storage"] = false
 	}
 
 	if data.minCertTimeLeft > 0 {

--- a/plugin/pki/env_test.go
+++ b/plugin/pki/env_test.go
@@ -162,12 +162,14 @@ var venafiTestFakeConfigDeprecatedStoreByCN = map[string]interface{}{
 	"generate_lease": true,
 	"store_by_cn":    true,
 	"store_pkey":     true,
+	"no_cache":       true,
 }
 
 var venafiTestFakeConfigDeprecatedStoreBySerial = map[string]interface{}{
 	"generate_lease":  true,
 	"store_by_serial": true,
 	"store_pkey":      true,
+	"no_cache":        true,
 }
 
 var venafiTestFakeConfigStoreByCN = map[string]interface{}{
@@ -180,21 +182,25 @@ var venafiTestFakeConfigStoreBySerial = map[string]interface{}{
 	"generate_lease": true,
 	"store_by":       "serial",
 	"store_pkey":     true,
+	"no_cache":       true,
 }
 
 var venafiTestFakeConfig = map[string]interface{}{
 	"generate_lease": true,
 	"store_pkey":     true,
+	"no_cache":       true,
 }
 
 var venafiTestFakeConfigNoStore = map[string]interface{}{
 	"generate_lease": true,
 	"no_store":       true,
+	"no_cache":       true,
 }
 
 var venafiTestFakeConfigNoStorePKey = map[string]interface{}{
 	"generate_lease": true,
 	"store_pkey":     false,
+	"no_cache":       true,
 }
 
 var venafiTestMixedTppAndCloudConfig = map[string]interface{}{

--- a/plugin/pki/path_roles.go
+++ b/plugin/pki/path_roles.go
@@ -135,7 +135,7 @@ attached to them. Defaults to "false".`,
 			"no_cache": {
 				Type:        framework.TypeBool,
 				Description: `When false, certificate requests will be looked into Vault's storage to prevent their issuance'`,
-				Default:     true,
+				Default:     false,
 			},
 		},
 

--- a/plugin/pki/path_roles.go
+++ b/plugin/pki/path_roles.go
@@ -132,9 +132,9 @@ attached to them. Defaults to "false".`,
 				Description: `When set, is used to determinate if certificate issuance is needed comparing certificate validity against desired remaining validity`,
 				Default:     time.Duration(30*24) * time.Hour,
 			},
-			"no_cache": {
+			"ignore_local_storage": {
 				Type:        framework.TypeBool,
-				Description: `When false, certificate requests will be looked into Vault's storage to prevent their issuance'`,
+				Description: `When true, bypasses prevent re-issue logic to issue new certificate'`,
 				Default:     false,
 			},
 		},
@@ -339,10 +339,10 @@ func (b *backend) pathRoleUpdate(ctx context.Context, req *logical.Request, data
 		entry.MinCertTimeLeft = minCertTimeLeft
 	}
 
-	_, isSet = data.GetOk("no_cache")
-	noCache := data.Get("no_cache").(bool)
-	if isSet && (entry.NoCache != noCache) {
-		entry.NoCache = noCache
+	_, isSet = data.GetOk("ignore_local_storage")
+	ignoreLocalStorage := data.Get("ignore_local_storage").(bool)
+	if isSet && (entry.IgnoreLocalStorage != ignoreLocalStorage) {
+		entry.IgnoreLocalStorage = ignoreLocalStorage
 	}
 
 	err = validateEntry(entry)
@@ -369,25 +369,25 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 
 	} else {
 		entry = &roleEntry{
-			ChainOption:      data.Get("chain_option").(string),
-			StoreByCN:        data.Get("store_by_cn").(bool),
-			StoreBySerial:    data.Get("store_by_serial").(bool),
-			StoreBy:          data.Get("store_by").(string),
-			NoStore:          data.Get("no_store").(bool),
-			ServiceGenerated: data.Get("service_generated_cert").(bool),
-			StorePrivateKey:  data.Get("store_pkey").(bool),
-			KeyType:          data.Get("key_type").(string),
-			KeyBits:          data.Get("key_bits").(int),
-			KeyCurve:         data.Get("key_curve").(string),
-			MaxTTL:           time.Duration(data.Get("max_ttl").(int)) * time.Second,
-			TTL:              time.Duration(data.Get("ttl").(int)) * time.Second,
-			IssuerHint:       data.Get("issuer_hint").(string),
-			GenerateLease:    data.Get("generate_lease").(bool),
-			ServerTimeout:    time.Duration(data.Get("server_timeout").(int)) * time.Second,
-			VenafiSecret:     data.Get("venafi_secret").(string),
-			Zone:             data.Get("zone").(string),
-			MinCertTimeLeft:  time.Duration(data.Get("min_cert_time_left").(int)) * time.Second,
-			NoCache:          data.Get("no_cache").(bool),
+			ChainOption:        data.Get("chain_option").(string),
+			StoreByCN:          data.Get("store_by_cn").(bool),
+			StoreBySerial:      data.Get("store_by_serial").(bool),
+			StoreBy:            data.Get("store_by").(string),
+			NoStore:            data.Get("no_store").(bool),
+			ServiceGenerated:   data.Get("service_generated_cert").(bool),
+			StorePrivateKey:    data.Get("store_pkey").(bool),
+			KeyType:            data.Get("key_type").(string),
+			KeyBits:            data.Get("key_bits").(int),
+			KeyCurve:           data.Get("key_curve").(string),
+			MaxTTL:             time.Duration(data.Get("max_ttl").(int)) * time.Second,
+			TTL:                time.Duration(data.Get("ttl").(int)) * time.Second,
+			IssuerHint:         data.Get("issuer_hint").(string),
+			GenerateLease:      data.Get("generate_lease").(bool),
+			ServerTimeout:      time.Duration(data.Get("server_timeout").(int)) * time.Second,
+			VenafiSecret:       data.Get("venafi_secret").(string),
+			Zone:               data.Get("zone").(string),
+			MinCertTimeLeft:    time.Duration(data.Get("min_cert_time_left").(int)) * time.Second,
+			IgnoreLocalStorage: data.Get("ignore_local_storage").(bool),
 		}
 	}
 
@@ -484,30 +484,30 @@ func getCredentialsWarnings(b *backend, ctx context.Context, s logical.Storage, 
 type roleEntry struct {
 
 	//Venafi values
-	Name             string
-	ChainOption      string        `json:"chain_option"`
-	StoreByCN        bool          `json:"store_by_cn"`
-	StoreBySerial    bool          `json:"store_by_serial"`
-	StoreBy          string        `json:"store_by"`
-	NoStore          bool          `json:"no_store"`
-	ServiceGenerated bool          `json:"service_generated_cert"`
-	StorePrivateKey  bool          `json:"store_pkey"`
-	KeyType          string        `json:"key_type"`
-	KeyBits          int           `json:"key_bits"`
-	KeyCurve         string        `json:"key_curve"`
-	LeaseMax         string        `json:"lease_max"`
-	Lease            string        `json:"lease"`
-	TTL              time.Duration `json:"ttl_duration"`
-	MaxTTL           time.Duration `json:"max_ttl_duration"`
-	IssuerHint       string        `json:"issuer_hint"`
-	GenerateLease    bool          `json:"generate_lease,omitempty"`
-	DeprecatedMaxTTL string        `json:"max_ttl"`
-	DeprecatedTTL    string        `json:"ttl"`
-	ServerTimeout    time.Duration `json:"server_timeout"`
-	VenafiSecret     string        `json:"venafi_secret"`
-	Zone             string        `json:"zone"`
-	MinCertTimeLeft  time.Duration `json:"min_cert_time_left"`
-	NoCache          bool          `json:"no_cache"`
+	Name               string
+	ChainOption        string        `json:"chain_option"`
+	StoreByCN          bool          `json:"store_by_cn"`
+	StoreBySerial      bool          `json:"store_by_serial"`
+	StoreBy            string        `json:"store_by"`
+	NoStore            bool          `json:"no_store"`
+	ServiceGenerated   bool          `json:"service_generated_cert"`
+	StorePrivateKey    bool          `json:"store_pkey"`
+	KeyType            string        `json:"key_type"`
+	KeyBits            int           `json:"key_bits"`
+	KeyCurve           string        `json:"key_curve"`
+	LeaseMax           string        `json:"lease_max"`
+	Lease              string        `json:"lease"`
+	TTL                time.Duration `json:"ttl_duration"`
+	MaxTTL             time.Duration `json:"max_ttl_duration"`
+	IssuerHint         string        `json:"issuer_hint"`
+	GenerateLease      bool          `json:"generate_lease,omitempty"`
+	DeprecatedMaxTTL   string        `json:"max_ttl"`
+	DeprecatedTTL      string        `json:"ttl"`
+	ServerTimeout      time.Duration `json:"server_timeout"`
+	VenafiSecret       string        `json:"venafi_secret"`
+	Zone               string        `json:"zone"`
+	MinCertTimeLeft    time.Duration `json:"min_cert_time_left"`
+	IgnoreLocalStorage bool          `json:"ignore_local_storage"`
 }
 
 func (r *roleEntry) ToResponseData() map[string]interface{} {
@@ -524,7 +524,7 @@ func (r *roleEntry) ToResponseData() map[string]interface{} {
 		"generate_lease":         r.GenerateLease,
 		"chain_option":           r.ChainOption,
 		"min_cert_time_left":     shortDurationString(r.MinCertTimeLeft),
-		"no_cache":               r.NoCache,
+		"ignore_local_storage":   r.IgnoreLocalStorage,
 	}
 	return responseData
 }

--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -227,14 +227,14 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request
 		certId = getCertIdHash(reqData, cfg.Zone, b.Logger())
 	}
 
-	if !role.NoCache && role.StorePrivateKey == true && (role.StoreBy == storeBySerialString || role.StoreBySerial == true) {
+	if !role.IgnoreLocalStorage && role.StorePrivateKey == true && (role.StoreBy == storeBySerialString || role.StoreBySerial == true) {
 		// if we don't receive a logic response, whenever is an error or the actual certificate found in storage
 		// means we need to issue a new one
 		logicalResp := preventReissue(b, ctx, req, &reqData, &cl, role, cfg.Zone)
 		if logicalResp != nil {
 			return logicalResp, nil
 		}
-	} else if !role.NoCache && role.StorePrivateKey == true && role.StoreBy == storeByHASHstring {
+	} else if !role.IgnoreLocalStorage && role.StorePrivateKey == true && role.StoreBy == storeByHASHstring {
 		logicalResp := preventReissueLocal(b, ctx, req, &reqData, role, certId)
 		if logicalResp != nil {
 			return logicalResp, nil

--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -227,14 +227,14 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, req *logical.Request
 		certId = getCertIdHash(reqData, cfg.Zone, b.Logger())
 	}
 
-	if &role.MinCertTimeLeft != nil && role.MinCertTimeLeft != time.Duration(0) && role.StorePrivateKey == true && (role.StoreBy == storeBySerialString || role.StoreBySerial == true) {
+	if !role.NoCache && role.StorePrivateKey == true && (role.StoreBy == storeBySerialString || role.StoreBySerial == true) {
 		// if we don't receive a logic response, whenever is an error or the actual certificate found in storage
 		// means we need to issue a new one
 		logicalResp := preventReissue(b, ctx, req, &reqData, &cl, role, cfg.Zone)
 		if logicalResp != nil {
 			return logicalResp, nil
 		}
-	} else if &role.MinCertTimeLeft != nil && role.MinCertTimeLeft != time.Duration(0) && role.StorePrivateKey == true && role.StoreBy == storeByHASHstring {
+	} else if !role.NoCache && role.StorePrivateKey == true && role.StoreBy == storeByHASHstring {
 		logicalResp := preventReissueLocal(b, ctx, req, &reqData, role, certId)
 		if logicalResp != nil {
 			return logicalResp, nil


### PR DESCRIPTION
This code provides a new flag to ignore local storage incase a fresh certificate is needed to be issued.
This is to still allow users to use prevent reissue feature, but occasionally bypassing the local storage to get fresh certificate 