### PR TITLE
Adds flags for issue path (ignore local storage and minimum time left)

### DIFF
--- a/plugin/pki/env_test.go
+++ b/plugin/pki/env_test.go
@@ -60,6 +60,11 @@ type testData struct {
 	ignoreLocalStorage   bool
 }
 
+type issueTestData struct {
+	minCertTimeLeft    time.Duration
+	ignoreLocalStorage bool
+}
+
 const (
 	venafiConfigTPP                         venafiConfigString = "TPP"
 	venafiConfigTPPPredefined               venafiConfigString = "TPPPredefined"
@@ -784,6 +789,85 @@ func (e *testEnv) IssueCertificateAndSaveSerialParallelism(t *testing.T, data te
 	checkStandardCert(t, data)
 	serial := resp.Data["serial_number"].(string)
 	return serial
+}
+
+func (e *testEnv) IssueCertificateAndSaveSerialWithIssuanceData(t *testing.T, data testData, configString venafiConfigString, issueTestData *issueTestData) {
+
+	var issueData map[string]interface{}
+
+	var altNames []string
+
+	if data.dnsNS != "" {
+		altNames = append(altNames, data.dnsNS)
+	}
+	if data.dnsEmail != "" {
+		altNames = append(altNames, data.dnsEmail)
+	}
+	if data.dnsIP != "" {
+		altNames = append(altNames, data.dnsIP)
+	}
+
+	issueData = map[string]interface{}{
+		"common_name":        data.cn,
+		"alt_names":          strings.Join(altNames, ","),
+		"ip_sans":            []string{data.onlyIP},
+		"private_key_format": "der",
+	}
+	if data.keyPassword != "" {
+		issueData["private_key_format"] = "der"
+	}
+
+	if issueTestData != nil {
+		issueData["ignore_local_storage"] = issueTestData.ignoreLocalStorage
+		issueData["min_cert_time_left"] = issueTestData.minCertTimeLeft
+	}
+
+	if data.privateKeyFormat != "" {
+		issueData["private_key_format"] = data.privateKeyFormat
+	}
+
+	if data.customFields != nil {
+		issueData["custom_fields"] = strings.Join(data.customFields, ",")
+	}
+
+	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "issue/" + e.RoleName,
+		Storage:   e.Storage,
+		Data:      issueData,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to issue certificate, %#v", resp.Data["error"])
+	}
+
+	if resp == nil {
+		t.Fatalf("should be on output on issue certificate, but response is nil: %#v", resp)
+	}
+
+	data.cert = resp.Data["certificate"].(string)
+	if data.keyPassword != "" {
+		encryptedKey := resp.Data["private_key"].(string)
+		b, _ := pem.Decode([]byte(encryptedKey))
+		b.Bytes, err = x509.DecryptPEMBlock(b, []byte(data.keyPassword))
+		if err != nil {
+			t.Fatal(err)
+		}
+		data.privateKey = string(pem.EncodeToMemory(b))
+	} else {
+		data.privateKey = resp.Data["private_key"].(string)
+	}
+
+	// it is needed to determine if we're checking cloud signed certificate in checkStandartCert
+	data.provider = configString
+
+	checkStandardCert(t, data)
+	// save certificate serial for the next test
+	e.CertificateSerial = resp.Data["serial_number"].(string)
 }
 
 func (e *testEnv) IssueCertificateAndValidateTTL(t *testing.T, data testData) {
@@ -2322,6 +2406,52 @@ func (e *testEnv) PreventReissuanceLocal(t *testing.T, data testData, config ven
 		// means that we went to issue another certificate which shouldn't have happened
 		// as we intend to present the one in storage
 		t.Fatal("The serials are different")
+	}
+}
+
+func (e *testEnv) PreventReissuanceLocalWithIssuanceData(t *testing.T, data testData, config venafiConfigString, issuanceData issueTestData) {
+
+	randString := e.TestRandString
+	domain := "vfidev.com"
+	data.cn = randString + "." + domain
+	commonName := data.cn
+	data.dnsNS = "maria-" + commonName + "," + "rose-" + commonName + "," + "bob-" + commonName + "," + "bob-" + commonName + "," + "shina-" + commonName
+	data.storeBy = "hash"
+	data.storePkey = true
+
+	e.writeVenafiToBackend(t, config)
+	e.writeRoleToBackendWithData(t, config, data)
+	e.IssueCertificateAndSaveSerialWithIssuanceData(t, data, config, &issuanceData)
+	currentCertificateSerial := e.CertificateSerial
+	e.IssueCertificateAndSaveSerialWithIssuanceData(t, data, config, &issuanceData)
+	nextCertificateSerial := e.CertificateSerial
+	if currentCertificateSerial != nextCertificateSerial {
+		// means that we went to issue another certificate which shouldn't have happened
+		// as we intend to present the one in storage
+		t.Fatal("The serials are different")
+	}
+}
+
+func (e *testEnv) NotPreventReissuanceLocalWithIssuanceData(t *testing.T, data testData, config venafiConfigString, issuanceData issueTestData) {
+
+	randString := e.TestRandString
+	domain := "vfidev.com"
+	data.cn = randString + "." + domain
+	commonName := data.cn
+	data.dnsNS = "maria-" + commonName + "," + "rose-" + commonName + "," + "bob-" + commonName + "," + "bob-" + commonName + "," + "shina-" + commonName
+	data.storeBy = "hash"
+	data.storePkey = true
+
+	e.writeVenafiToBackend(t, config)
+	e.writeRoleToBackendWithData(t, config, data)
+	e.IssueCertificateAndSaveSerialWithIssuanceData(t, data, config, &issuanceData)
+	currentCertificateSerial := e.CertificateSerial
+	e.IssueCertificateAndSaveSerialWithIssuanceData(t, data, config, &issuanceData)
+	nextCertificateSerial := e.CertificateSerial
+	if currentCertificateSerial == nextCertificateSerial {
+		// since a new SAN DNS was provided in second run, we should have issued
+		// another certificate, so serials should be different
+		t.Fatal("The serials are equal")
 	}
 }
 


### PR DESCRIPTION
Adds flags for issuance path:
- `ignore_local_storage`: bypasses prevent re-issue logic to issue new certificate
- `min_cert_time_left`: used to determinate if certificate issuance is needed comparing certificate validity against desired remaining validity

This is, to specify these features at the certificate level during issuance