### PR TITLE
Adds more log messages and fixes bug in setting up token process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.12.1 (January 19, 2023)
+* Added `ignore_local_storage` and `min_cert_time_left` new attributes at `issue` path, which
+bypasses `prevent-reissue-local` feature, if enabled, and requests the certificate, and handles
+certificate time left considered to be valid, respectively
+* Fixes bug that wouldn't let to create `venafi` secret in a Vault cluster environment where refresh tokens were provided
+* Added more logs for refresh token process
+* Starting from release, binaries are signed
+
 # v0.12.0 (December 27, 2022)
 * Added ability to ignore search-certificate in local storage. Fixes behaviour for prevent-reissue features to have certificate default validity.
 * Introduced `proactive refresh` feature, which now relies on handling refreshing the `access_token` by passing two refresh tokens in the `venafi` secret (`refresh_token` and `refresh_token_2`)

--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -1042,21 +1042,21 @@ func validateAccessToken(b *backend, ctx context.Context, connector endpoint.Con
 		if err != nil {
 			return nil, err
 		}
-		b.Logger().Info(fmt.Sprintf("cfg access_token %s", cfg.Credentials.AccessToken))
-		b.Logger().Info(fmt.Sprintf("cfg refresh_token %s", cfg.Credentials.RefreshToken))
+		b.Logger().Info("Updating access_token")
 		err = updateAccessToken(b, ctx, logReq, cfg, role)
 		if err != nil {
 			return nil, err
 		}
+		b.Logger().Info("Successfully updated tokens. Refreshing the connector with new token")
 		var newConnector endpoint.Connector
 		newConnector, cfg, err = b.ClientVenafi(ctx, logReq, role)
 		if err != nil {
-			b.Logger().Error("got error: token is not ready")
+			b.Logger().Error(fmt.Sprintf("got error when getting new connector: %s", err.Error()))
 			return nil, err
 		}
 		connector = newConnector
 	}
-	b.Logger().Info("successfully updated connector with new token")
+	b.Logger().Info("Successfully updated connector with new token")
 	return connector, nil
 }
 

--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -195,7 +195,7 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, logicalRequest *logi
 	// here we already filter proper "Zone" to later use with cfg.Zone
 	connector, cfg, err := b.ClientVenafi(ctx, logicalRequest, role)
 	if err != nil {
-		b.Logger().Error("error creating Venafi connector: %s", err.Error())
+		b.Logger().Error(fmt.Sprintf("error creating Venafi connector: %s", err.Error()))
 		return nil, err
 	}
 
@@ -212,8 +212,8 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, logicalRequest *logi
 		}
 		if secretEntry.RefreshToken != "" && secretEntry.RefreshToken2 != "" {
 			connector, err = validateAccessToken(b, ctx, connector, cfg, logicalRequest, role)
-			b.Logger().Error("error validating access token: %s", err.Error())
 			if err != nil {
+				b.Logger().Error("error validating access token: %s", err.Error())
 				return nil, err
 			}
 		}

--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -207,6 +207,7 @@ func (b *backend) pathVenafiCertObtain(ctx context.Context, logicalRequest *logi
 		}
 		if secretEntry.RefreshToken != "" && secretEntry.RefreshToken2 != "" {
 			connector, err = validateAccessToken(b, ctx, connector, cfg, logicalRequest, role)
+			b.Logger().Error("error validating access token: %s", err.Error())
 			if err != nil {
 				return nil, err
 			}
@@ -1049,11 +1050,12 @@ func validateAccessToken(b *backend, ctx context.Context, connector endpoint.Con
 		var newConnector endpoint.Connector
 		newConnector, cfg, err = b.ClientVenafi(ctx, logReq, role)
 		if err != nil {
-			b.Logger().Debug("got error: token is not ready")
+			b.Logger().Error("got error: token is not ready")
 			return nil, err
 		}
 		connector = newConnector
 	}
+	b.Logger().Info("successfully updated connector with new token")
 	return connector, nil
 }
 

--- a/plugin/pki/path_venafi_secrets.go
+++ b/plugin/pki/path_venafi_secrets.go
@@ -385,13 +385,16 @@ func (p *venafiSecretEntry) ToResponseData() map[string]interface{} {
 		//Sensible data will not be disclosed.
 		//tpp_password, api_key, access_token, refresh_token
 
-		"url":               p.URL,
-		"zone":              p.Zone,
-		"tpp_user":          p.TppUser,
-		"tpp_password":      p.getStringMask(),
-		"access_token":      p.getStringMask(),
-		"refresh_token":     p.getStringMask(),
-		"refresh_token_2":   p.getStringMask(),
+		"url":          p.URL,
+		"zone":         p.Zone,
+		"tpp_user":     p.TppUser,
+		"tpp_password": p.getStringMask(),
+		//"access_token":      p.getStringMask(),
+		//"refresh_token":     p.getStringMask(),
+		//"refresh_token_2":   p.getStringMask(),
+		"access_token":      p.AccessToken,
+		"refresh_token":     p.RefreshToken,
+		"refresh_token_2":   p.RefreshToken2,
 		"refresh_interval":  shortDurationString(p.RefreshInterval),
 		"next_refresh":      p.NextRefresh,
 		"apikey":            p.getStringMask(),

--- a/plugin/pki/path_venafi_secrets.go
+++ b/plugin/pki/path_venafi_secrets.go
@@ -175,7 +175,7 @@ func (b *backend) pathVenafiSecretDelete(ctx context.Context, req *logical.Reque
 func (b *backend) pathVenafiSecretCreate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	var err error
 	name := data.Get("name").(string)
-
+	b.Logger().Info(fmt.Sprintf("Creating Venafi secret: %s", name))
 	url := data.Get("url").(string)
 	var tppUrl, cloudUrl string
 
@@ -205,22 +205,27 @@ func (b *backend) pathVenafiSecretCreate(ctx context.Context, req *logical.Reque
 		Fakemode:        data.Get("fakemode").(bool),
 	}
 
+	b.Logger().Info(fmt.Sprintf("Validating data for venafi secret %s", name))
 	err = validateVenafiSecretEntry(entry)
 	if err != nil {
+		b.Logger().Error(fmt.Sprintf("Error with venafi secret data: %s", err.Error()))
 		return logical.ErrorResponse(err.Error()), nil
 	}
-
 	if entry.RefreshToken != "" && !entry.Fakemode {
-
+		b.Logger().Info("Refresh token pair is provided. Setting up data")
 		for i := 0; i < 2; i++ {
 
+			b.Logger().Info("Refresh token pair is provided. Setting up data")
 			cfg, err := createConfigFromFieldData(entry)
 			if err != nil {
+				b.Logger().Error(fmt.Sprintf("Error during venafi secret creation: creating config error: %s", err.Error()))
 				return logical.ErrorResponse(err.Error()), nil
 			}
 
+			b.Logger().Info("Refreshing token during Venafi secret creation")
 			tokenInfo, err := getAccessData(cfg)
 			if err != nil {
+				b.Logger().Error(fmt.Sprintf("Error during venafi secret creation: refreshing tokens error: %s", err.Error()))
 				return logical.ErrorResponse(err.Error()), nil
 			}
 
@@ -228,6 +233,7 @@ func (b *backend) pathVenafiSecretCreate(ctx context.Context, req *logical.Reque
 				// ensure refresh interval is proactive by not allowing it to be longer than access token is valid
 				maxInterval := time.Until(time.Unix(int64(tokenInfo.Expires), 0)).Round(time.Minute) - time.Duration(30)*time.Second
 				if maxInterval < entry.RefreshInterval {
+					b.Logger().Info("Refresh interval is not correct since is longer than access token validity. Setting up a proper one")
 					entry.RefreshInterval = maxInterval
 				}
 
@@ -245,16 +251,21 @@ func (b *backend) pathVenafiSecretCreate(ctx context.Context, req *logical.Reque
 				}
 			}
 		}
+		b.Logger().Info("Success setting up refresh token data of Venafi secret")
 	}
 
 	//Store it
+	b.Logger().Info("Setting up data for entry of Venafi secret")
 	jsonEntry, err := logical.StorageEntryJSON(CredentialsRootPath+name, entry)
 	if err != nil {
+		b.Logger().Error(fmt.Sprintf("Error during venafi secret creation: error setting up refresh tokens for storage: %s", err.Error()))
 		return nil, err
 	}
 
+	b.Logger().Info("Storing entry of Venafi secret")
 	err = req.Storage.Put(ctx, jsonEntry)
 	if err != nil {
+		b.Logger().Error(fmt.Sprintf("Error during venafi secret creation: error storing refresh tokens: %s", err.Error()))
 		return nil, err
 	}
 
@@ -269,9 +280,10 @@ func (b *backend) pathVenafiSecretCreate(ctx context.Context, req *logical.Reque
 			Redirect: "",
 			Warnings: warnings,
 		}
+		b.Logger().Info(fmt.Sprintf("Sucess on creating Venafi secret %s (with warnings)", name))
 		return logResp, nil
 	}
-
+	b.Logger().Info(fmt.Sprintf("Sucess on creating Venafi secret %s", name))
 	return nil, nil
 }
 

--- a/plugin/pki/path_venafi_secrets.go
+++ b/plugin/pki/path_venafi_secrets.go
@@ -215,7 +215,7 @@ func (b *backend) pathVenafiSecretCreate(ctx context.Context, req *logical.Reque
 		b.Logger().Info("Refresh token pair is provided. Setting up data")
 		for i := 0; i < 2; i++ {
 
-			b.Logger().Info("Refresh token pair is provided. Setting up data")
+			b.Logger().Info("Refresh setting config for refresjing tokens")
 			cfg, err := createConfigFromFieldData(entry)
 			if err != nil {
 				b.Logger().Error(fmt.Sprintf("Error during venafi secret creation: creating config error: %s", err.Error()))
@@ -223,6 +223,8 @@ func (b *backend) pathVenafiSecretCreate(ctx context.Context, req *logical.Reque
 			}
 
 			b.Logger().Info("Refreshing token during Venafi secret creation")
+			b.Logger().Info(fmt.Sprintf("current provided access_token: %s", cfg.Credentials.AccessToken))
+			b.Logger().Info(fmt.Sprintf("current provided refresh_token: %s", cfg.Credentials.RefreshToken))
 			tokenInfo, err := getAccessData(cfg)
 			if err != nil {
 				b.Logger().Error(fmt.Sprintf("Error during venafi secret creation: refreshing tokens error: %s", err.Error()))

--- a/plugin/pki/path_venafi_secrets.go
+++ b/plugin/pki/path_venafi_secrets.go
@@ -222,19 +222,17 @@ func (b *backend) pathVenafiSecretCreate(ctx context.Context, req *logical.Reque
 		return logical.ErrorResponse(err.Error()), nil
 	}
 	if entry.RefreshToken != "" && !entry.Fakemode {
-		b.Logger().Info("Refresh token pair is provided. Setting up data")
+		b.Logger().Info("Refresh tokens are provided. Setting up data")
 		for i := 0; i < 2; i++ {
 
-			b.Logger().Info("Refresh setting config for refresjing tokens")
+			b.Logger().Info("creating config for refreshing tokens")
 			cfg, err := createConfigFromFieldData(entry)
 			if err != nil {
 				b.Logger().Error(fmt.Sprintf("Error during venafi secret creation: creating config error: %s", err.Error()))
 				return logical.ErrorResponse(err.Error()), nil
 			}
 
-			b.Logger().Info("Refreshing token during Venafi secret creation")
-			b.Logger().Info(fmt.Sprintf("current provided access_token: %s", cfg.Credentials.AccessToken))
-			b.Logger().Info(fmt.Sprintf("current provided refresh_token: %s", cfg.Credentials.RefreshToken))
+			b.Logger().Info("Refreshing tokens during Venafi secret creation")
 			tokenInfo, err := getAccessData(cfg)
 			if err != nil {
 				b.Logger().Error(fmt.Sprintf("Error during venafi secret creation: refreshing tokens error: %s", err.Error()))
@@ -397,16 +395,13 @@ func (p *venafiSecretEntry) ToResponseData() map[string]interface{} {
 		//Sensible data will not be disclosed.
 		//tpp_password, api_key, access_token, refresh_token
 
-		"url":          p.URL,
-		"zone":         p.Zone,
-		"tpp_user":     p.TppUser,
-		"tpp_password": p.getStringMask(),
-		//"access_token":      p.getStringMask(),
-		//"refresh_token":     p.getStringMask(),
-		//"refresh_token_2":   p.getStringMask(),
-		"access_token":      p.AccessToken,
-		"refresh_token":     p.RefreshToken,
-		"refresh_token_2":   p.RefreshToken2,
+		"url":               p.URL,
+		"zone":              p.Zone,
+		"tpp_user":          p.TppUser,
+		"tpp_password":      p.getStringMask(),
+		"access_token":      p.getStringMask(),
+		"refresh_token":     p.getStringMask(),
+		"refresh_token_2":   p.getStringMask(),
 		"refresh_interval":  shortDurationString(p.RefreshInterval),
 		"next_refresh":      p.NextRefresh,
 		"apikey":            p.getStringMask(),

--- a/plugin/pki/util.go
+++ b/plugin/pki/util.go
@@ -247,11 +247,7 @@ func isTokenRefreshNeeded(b *backend, ctx context.Context, storage logical.Stora
 	if err != nil {
 		return false, "", err
 	}
-	now := time.Now()
-	b.Logger().Info(fmt.Sprintf("Current time: %s", now.String()))
-	refreshNeeded := secretEntry.NextRefresh.Before(now)
-	b.Logger().Info(fmt.Sprintf("Refresh Needed: %v", refreshNeeded))
-	return refreshNeeded, secretEntry.RefreshToken2, nil
+	return secretEntry.NextRefresh.Before(time.Now()), secretEntry.RefreshToken2, nil
 }
 
 func updateAccessToken(b *backend, ctx context.Context, req *logical.Request, cfg *vcert.Config, role *roleEntry) error {

--- a/plugin/pki/util.go
+++ b/plugin/pki/util.go
@@ -278,6 +278,9 @@ func updateAccessToken(b *backend, ctx context.Context, req *logical.Request, cf
 	tppConnector.SetHTTPClient(httpClient)
 
 	b.Logger().Info("Refreshing token")
+	b.Logger().Info(fmt.Sprintf("current set access_token: %s", cfg.Credentials.AccessToken))
+	b.Logger().Info(fmt.Sprintf("current set refresh_token: %s", cfg.Credentials.RefreshToken))
+	b.Logger().Info(fmt.Sprintf("current refresh_token_2 for refrehsing: %s", refreshToken))
 	var resp tpp.OauthRefreshAccessTokenResponse
 	resp, err = tppConnector.RefreshAccessToken(&endpoint.Authentication{
 		RefreshToken: refreshToken,


### PR DESCRIPTION
- Added more log messages for token process.
- Fixes bug that, when reaching a secondary node when setting Venafi secret with refresh tokens, would lead to error.