### PR TITLE
fix issue on make release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,5 +369,5 @@ release:
 	echo '```' > release.txt
 	cd artifacts; sha256sum * >> ../release.txt
 	echo '```' >> release.txt
-	go get -u github.com/tcnksm/ghr
+	go install github.com/tcnksm/ghr@latest
 	ghr -prerelease -n $$RELEASE_VERSION -body="$$(cat ./release.txt)" $$RELEASE_VERSION artifacts/


### PR DESCRIPTION
- For latest Golang images, we need this change in order to properly install `ghr` library