### PR TITLE
security: CWE-639: prevent cross-role private key disclosure — VC-53759

### DIFF
--- a/plugin/pki/path_venafi_cert_read.go
+++ b/plugin/pki/path_venafi_cert_read.go
@@ -51,15 +51,6 @@ func (b *backend) pathVenafiCertRead(ctx context.Context, req *logical.Request, 
 		"serial_number":     cert.SerialNumber,
 		"certificate_chain": cert.CertificateChain,
 		"certificate":       cert.Certificate,
-		"private_key":       cert.PrivateKey,
-	}
-
-	if keyPassword != "" {
-		encryptedPrivateKeyPem, err := util.EncryptPrivateKey(cert.PrivateKey, keyPassword)
-		if err != nil {
-			return nil, err
-		}
-		respData["private_key"] = encryptedPrivateKeyPem
 	}
 
 	return &logical.Response{


### PR DESCRIPTION
## Summary

Removes private key from the certificate read endpoint response to prevent cross-role private key disclosure (CWE-639).

## Finding

**CWE-639 / CWE-863: Authorization Bypass Through User-Controlled Key**

The `pathVenafiCertRead()` function in `plugin/pki/path_venafi_cert_read.go` returns `cert.PrivateKey` to any caller with read access to `<mount>/cert/*` without verifying which role issued the certificate. This allows any authenticated principal to disclose private keys issued under other tenants' roles on the same mount.

**CVSS**: 6.0 (CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N)

## Remediation

Removed the `private_key` field from the certificate read response (lines 54, 57-63 in `path_venafi_cert_read.go`). This aligns with built-in PKI backend semantics where private keys are only returned during certificate issuance, not on subsequent reads.

**Changes:**
- Removed plaintext private key from response map
- Removed encrypted private key logic (key_password handling)

## Verification

This is a minimal, focused fix that only removes the vulnerable data exposure. The certificate, certificate chain, serial number, and UID remain accessible for legitimate read operations.

**Related**: VC-53759