### PR TITLE
security: CWE-476: nil deref nonexistent role dos — VC-53758

### DIFF
--- a/plugin/pki/path_venafi_cert_enroll.go
+++ b/plugin/pki/path_venafi_cert_enroll.go
@@ -145,13 +145,13 @@ func (b *backend) pathVenafiIssue(ctx context.Context, req *logical.Request, dat
 	b.Logger().Debug(fmt.Sprintf("Using role: %s", roleName))
 	// Get the role
 	role, err := b.getRole(ctx, req.Storage, roleName)
-	role.Name = roleName
 	if err != nil {
 		return nil, err
 	}
 	if role == nil {
 		return nil, fmt.Errorf("unknown role: %s", roleName)
 	}
+	role.Name = roleName
 
 	if role.KeyType == "any" {
 		return nil, errors.New(`role key type "any" not allowed for issuing certificates, only signing`)
@@ -171,7 +171,6 @@ func (b *backend) pathVenafiSign(ctx context.Context, req *logical.Request, data
 
 	// Get the role
 	role, err := b.getRole(ctx, req.Storage, roleName)
-	role.Name = roleName
 
 	if err != nil {
 		return nil, err
@@ -179,6 +178,7 @@ func (b *backend) pathVenafiSign(ctx context.Context, req *logical.Request, data
 	if role == nil {
 		return logical.ErrorResponse(fmt.Sprintf("unknown role: %s", roleName)), nil
 	}
+	role.Name = roleName
 	logicResp, err := b.pathVenafiCertObtain(ctx, req, data, role, true)
 	if err != nil {
 		return nil, err

--- a/plugin/pki/path_venafi_cert_revoke.go
+++ b/plugin/pki/path_venafi_cert_revoke.go
@@ -201,6 +201,9 @@ func getDnFromSerial(c *endpoint.Connector, serial string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if len(data.Certificates) == 0 {
+		return "", errors.New("no certificates found for the given serial")
+	}
 	dn := data.Certificates[0].CertificateRequestId
 
 	return dn, nil


### PR DESCRIPTION
## Summary

Fixes CWE-476 nil pointer dereference vulnerability that could cause a denial-of-service by terminating the plugin process when accessing a nonexistent role.

## Finding

**CVSS**: 7.1 (CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N)

**Impact**: `pathVenafiIssue()` and `pathVenafiSign()` dereference the `*roleEntry` returned by `getRole()` before evaluating the err/nil guards. A request naming a nonexistent role causes a nil-pointer panic that terminates the plugin process and renders the secrets-engine mount unavailable.

**Root Cause**: 
- `plugin/pki/path_venafi_cert_enroll.go:148/174`: `role.Name = roleName` assignment precedes the `if err != nil` and `if role == nil` checks
- `getRole` returns `(nil, nil)` when the role is absent
- Secondary issue in `path_venafi_cert_revoke.go:204`: indexes `data.Certificates[0]` without checking `len(data.Certificates) > 0`

## Remediation

1. Moved `role.Name = roleName` after nil/error guards in both `pathVenafiIssue` and `pathVenafiSign` functions
2. Added `len(data.Certificates) == 0` guard in `getDnFromSerial` to prevent index out of bounds panic

## Verification

- Minimal changes applied to fix the specific vulnerability
- Only modified vulnerable code paths identified in the security finding
- No refactoring or unrelated changes introduced

🤖 Generated with Pattern-C security fixer