### PR TITLE
Fix certificate revocation identifiers

### DIFF
--- a/plugin/pki/path_venafi_cert_revoke.go
+++ b/plugin/pki/path_venafi_cert_revoke.go
@@ -2,6 +2,10 @@ package pki
 
 import (
 	"context"
+	"crypto/sha1" // #nosec G505
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"strings"
@@ -27,6 +31,10 @@ func pathVenafiCertRevoke(b *backend) *framework.Path {
 			"certificate_uid": {
 				Type:        framework.TypeString,
 				Description: "Common name for created certificate",
+			},
+			"serial_number": {
+				Type:        framework.TypeString,
+				Description: "Serial number of the certificate to revoke",
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -63,13 +71,16 @@ func (b *backend) venafiCertRevoke(ctx context.Context, req *logical.Request, d 
 		return logical.ErrorResponse("role key type \"any\" not allowed for issuing certificates, only signing"), nil
 	}
 
-	id := d.Get("certificate_uid").(string)
+	id := getRevokeCertificateID(d, role)
+	if id == "" {
+		return logical.ErrorResponse("missing certificate_uid or serial_number"), nil
+	}
 
 	if exists, err := isCertificateStored(ctx, req, id, role); !exists {
 		if err != nil {
-			return logical.ErrorResponse(err.Error()), err
+			return logical.ErrorResponse(err.Error()), nil
 		}
-		return logical.ErrorResponse("the certificate is not stored"), errors.New("the certificate is not stored")
+		return logical.ErrorResponse("the certificate is not stored"), nil
 	}
 
 	// Load the stored certificate to verify ownership
@@ -91,17 +102,12 @@ func (b *backend) venafiCertRevoke(ctx context.Context, req *logical.Request, d 
 		return logical.ErrorResponse(err.Error()), nil
 	}
 
-	dn, err := getDn(b, &cl, ctx, req, cfg.Zone, id, role.StoreBy)
-
+	revReq, err := getRevocationRequest(b, &cl, ctx, req, cfg.Zone, id, role)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
 
-	revReq := certificate.RevocationRequest{}
-
-	revReq.CertificateDN = dn
-
-	_, err = cl.RevokeCertificate(&revReq)
+	_, err = cl.RevokeCertificate(revReq)
 
 	if err != nil {
 		return logical.ErrorResponse("Failed to revoke certificate: %s", err), nil
@@ -116,11 +122,27 @@ func (b *backend) venafiCertRevoke(ctx context.Context, req *logical.Request, d 
 	return nil, nil
 }
 
+func getRevokeCertificateID(d *framework.FieldData, role *roleEntry) string {
+	id := d.Get("certificate_uid").(string)
+	if id == "" {
+		id = d.Get("serial_number").(string)
+	}
+	return normalizeRevokeCertificateID(id, role)
+}
+
+func normalizeRevokeCertificateID(id string, role *roleEntry) string {
+	if id == "" {
+		return id
+	}
+	if role.StoreBy == util.StoreByCNString || role.StoreByCN {
+		return id
+	}
+	return util.NormalizeSerial(id)
+}
+
 func deleteCertificateEntry(ctx context.Context, req *logical.Request, id string, role *roleEntry) error {
 
-	if !role.StoreByCN {
-		id = strings.ReplaceAll(id, ":", "-")
-	}
+	id = normalizeRevokeCertificateID(id, role)
 
 	path := "certs/" + id
 
@@ -142,14 +164,7 @@ func isCertificateStored(ctx context.Context, req *logical.Request, id string, r
 		return false, errors.New("certificate is not stored")
 	}
 
-	if !role.StoreByCN {
-		if strings.Contains(id, ":") {
-			id = strings.ReplaceAll(id, ":", "-")
-		}
-		if strings.Contains(id, "-") {
-			id = strings.ReplaceAll(id, "-", "-")
-		}
-	}
+	id = normalizeRevokeCertificateID(id, role)
 
 	path := "certs/" + id
 	entry, err := req.Storage.Get(ctx, path)
@@ -163,6 +178,47 @@ func isCertificateStored(ctx context.Context, req *logical.Request, id string, r
 	}
 
 	return true, nil
+}
+
+func getRevocationRequest(b *backend, c *endpoint.Connector, ctx context.Context, req *logical.Request, zone string, certID string, role *roleEntry) (*certificate.RevocationRequest, error) {
+	revReq := certificate.RevocationRequest{}
+
+	if (*c).GetType() == endpoint.ConnectorTypeCloud {
+		thumbprint, err := getThumbprintFromStorage(b, ctx, req, certID)
+		if err != nil {
+			return nil, err
+		}
+		revReq.Thumbprint = thumbprint
+		return &revReq, nil
+	}
+
+	dn, err := getDn(b, c, ctx, req, zone, certID, role.StoreBy)
+	if err != nil {
+		return nil, err
+	}
+	revReq.CertificateDN = dn
+
+	return &revReq, nil
+}
+
+func getThumbprintFromStorage(b *backend, ctx context.Context, req *logical.Request, certID string) (string, error) {
+	cert, err := loadCertificateFromStorage(b, ctx, req, certID, "")
+	if err != nil {
+		return "", err
+	}
+
+	block, _ := pem.Decode([]byte(cert.Certificate))
+	if block == nil {
+		return "", errors.New("failed to parse stored certificate PEM")
+	}
+
+	parsedCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", err
+	}
+
+	thumbprint := sha1.Sum(parsedCert.Raw)
+	return strings.ToUpper(hex.EncodeToString(thumbprint[:])), nil
 }
 
 func getDn(b *backend, c *endpoint.Connector, ctx context.Context, req *logical.Request, zone string, CertId string, storeByType string) (string, error) {

--- a/plugin/pki/path_venafi_cert_revoke_test.go
+++ b/plugin/pki/path_venafi_cert_revoke_test.go
@@ -1,0 +1,203 @@
+package pki
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1" // #nosec G505
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Venafi/vcert/v5/pkg/certificate"
+	"github.com/Venafi/vcert/v5/pkg/endpoint"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+
+	"github.com/Venafi/vault-pki-backend-venafi/plugin/util"
+)
+
+func TestGetRevokeCertificateIDAcceptsSerialNumber(t *testing.T) {
+	schema := pathVenafiCertRevoke(&backend{}).Fields
+	role := &roleEntry{StoreBy: util.StoreBySerialString}
+
+	data := &framework.FieldData{
+		Schema: schema,
+		Raw: map[string]interface{}{
+			"serial_number": "AA:BB:CC",
+		},
+	}
+	id := getRevokeCertificateID(data, role)
+	if id != "aa-bb-cc" {
+		t.Fatalf("expected normalized serial_number, got %q", id)
+	}
+
+	data = &framework.FieldData{
+		Schema: schema,
+		Raw: map[string]interface{}{
+			"certificate_uid": "DD:EE:FF",
+		},
+	}
+	id = getRevokeCertificateID(data, role)
+	if id != "dd-ee-ff" {
+		t.Fatalf("expected compatible normalized certificate_uid, got %q", id)
+	}
+}
+
+func TestVenafiCertRevokeUnknownIdentifierReturnsLogicalError(t *testing.T) {
+	env, err := NewIntegrationTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	role := roleEntry{
+		StoreBy:      util.StoreBySerialString,
+		VenafiSecret: env.VenafiSecretName,
+	}
+	entry, err := logical.StorageEntryJSON("role/"+env.RoleName, role)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := env.Storage.Put(env.Context, entry); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := env.Backend.HandleRequest(env.Context, &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "revoke/" + env.RoleName,
+		Storage:   env.Storage,
+		Data: map[string]interface{}{
+			"serial_number": "AA:BB:CC",
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected clean logical error response, got Go error: %v", err)
+	}
+	if resp == nil || !resp.IsError() {
+		t.Fatalf("expected logical error response, got %#v", resp)
+	}
+}
+
+func TestVenafiCertRevokeMissingIdentifierReturnsLogicalError(t *testing.T) {
+	env, err := NewIntegrationTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	role := roleEntry{
+		StoreBy:      util.StoreBySerialString,
+		VenafiSecret: env.VenafiSecretName,
+	}
+	entry, err := logical.StorageEntryJSON("role/"+env.RoleName, role)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := env.Storage.Put(env.Context, entry); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := env.Backend.HandleRequest(env.Context, &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "revoke/" + env.RoleName,
+		Storage:   env.Storage,
+	})
+	if err != nil {
+		t.Fatalf("expected clean logical error response, got Go error: %v", err)
+	}
+	if resp == nil || !resp.IsError() {
+		t.Fatalf("expected logical error response, got %#v", resp)
+	}
+}
+
+func TestGetRevocationRequestCloudUsesStoredCertificateThumbprint(t *testing.T) {
+	ctx := context.Background()
+	storage := &logical.InmemStorage{}
+	conf := logical.TestBackendConfig()
+	conf.StorageView = storage
+	b := Backend(conf)
+	if err := b.Setup(ctx, conf); err != nil {
+		t.Fatal(err)
+	}
+
+	certPEM, rawCert := testCertificatePEM(t)
+	entry, err := logical.StorageEntryJSON("certs/aa-bb-cc", VenafiCert{
+		Certificate:  certPEM,
+		SerialNumber: "aa:bb:cc",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.Put(ctx, entry); err != nil {
+		t.Fatal(err)
+	}
+
+	connector := &revokeTestConnector{connectorType: endpoint.ConnectorTypeCloud}
+	var cl endpoint.Connector = connector
+	req := &logical.Request{Storage: storage}
+	role := &roleEntry{StoreBy: util.StoreBySerialString}
+
+	revReq, err := getRevocationRequest(b, &cl, ctx, req, "", "aa-bb-cc", role)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if connector.searchCalled {
+		t.Fatal("Cloud revocation should not call SearchCertificates")
+	}
+	if revReq.CertificateDN != "" {
+		t.Fatalf("expected no CertificateDN for Cloud revocation, got %q", revReq.CertificateDN)
+	}
+
+	thumbprint := sha1.Sum(rawCert)
+	expectedThumbprint := strings.ToUpper(hex.EncodeToString(thumbprint[:]))
+	if revReq.Thumbprint != expectedThumbprint {
+		t.Fatalf("expected thumbprint %q, got %q", expectedThumbprint, revReq.Thumbprint)
+	}
+}
+
+func testCertificatePEM(t *testing.T) (string, []byte) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "revoke-test.example.com",
+		},
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	block := &pem.Block{Type: "CERTIFICATE", Bytes: der}
+	return string(pem.EncodeToMemory(block)), der
+}
+
+type revokeTestConnector struct {
+	endpoint.Connector
+	connectorType endpoint.ConnectorType
+	searchCalled  bool
+}
+
+func (c *revokeTestConnector) GetType() endpoint.ConnectorType {
+	return c.connectorType
+}
+
+func (c *revokeTestConnector) SearchCertificates(_ *certificate.SearchRequest) (*certificate.CertSearchResponse, error) {
+	c.searchCalled = true
+	return nil, nil
+}
+
+var _ endpoint.Connector = (*revokeTestConnector)(nil)


### PR DESCRIPTION
Fixes #192

## Summary
- Accept `serial_number` as an alternate revoke input while preserving `certificate_uid`.
- Normalize serial-backed revoke IDs before Vault storage lookup/delete.
- Return clean logical error responses for missing or unknown revoke identifiers.
- For Certificate Manager SaaS / Venafi Cloud revocation, derive the certificate thumbprint from the stored PEM and send it as `RevocationRequest.Thumbprint`, avoiding unsupported `SearchCertificates`.
- Preserve the existing TPP `CertificateDN` behavior.

## Tests
- Before rebasing onto the latest `master`: `go test ./plugin/pki` passed.
- After rebasing onto the latest `master`: not rerun, because current `master` does not compile locally due to an unrelated unused import in `plugin/pki/path_venafi_cert_read.go` from recent upstream changes.
- Intentionally did not change the unrelated read path or its tests to keep this PR scoped to revocation behavior.

## Notes
- This change is scoped to backend revoke behavior once a revoke request reaches the plugin.
- This PR does not change Vault lease revocation behavior; it only fixes the explicit revoke path handled by `revoke/<role>`.