### PR TITLE
Add NGTS (Strata Cloud Manager) backend support - VC-54960

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.16.0 (June 23, 2026)
+* Adds support for Strata Cloud Manager (NGTS) as a fourth backend: issue, sign, read, and revoke
+* NGTS authenticates with an OAuth2 service account (`ngts_client_id`, `ngts_client_secret`, `ngts_token_url`, `ngts_scope`) or a pre-issued `ngts_access_token`
+* Hardens the NGTS token URL (credential sink): coerces `http://`→`https://` and rejects hosts outside `*.paloaltonetworks.com`
+* NGTS revoke (and Cloud revoke) compute the certificate thumbprint locally from the stored certificate
+* Upgrades the VCert SDK to v5.13.7
+
 # v0.15.1 (January 23, 2026)
 * golangci-lint re-enabled
 

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,9 @@ test_tpp:
 test_vaas:
 	go test -tags=vaas -run  ^TestVAAS -v github.com/Venafi/vault-pki-backend-venafi/plugin/pki
 
+test_ngts:
+	go test -tags=ngts -run ^TestNGTS -v github.com/Venafi/vault-pki-backend-venafi/plugin/pki
+
 test_fake:
 	go test -run  ^TestFake -v github.com/Venafi/vault-pki-backend-venafi/plugin/pki
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,46 @@ Venafi secrets engine:
    Success! Data written to: venafi-pki/venafi/vaas
    ```
 
+   **Strata Cloud Manager (NGTS)**:
+
+   NGTS uses a service account (OAuth2 client-credentials). The zone is the **Issuing
+   Template (CIT) alias only** — there is no `Application\Template` split. The `ngts_scope`
+   must be `tsg_id:` followed by exactly 10 digits.
+
+   ```bash
+   vault write venafi-pki/venafi/ngts \
+       url="https://api.strata.paloaltonetworks.com/ngts" \
+       ngts_token_url="https://auth.apps.paloaltonetworks.com/oauth2/access_token" \
+       ngts_client_id="ts-service-account-1@1234567890.iam.panserviceaccount.com" \
+       ngts_client_secret="xxxxxxxxxxxxxxxxxxxxxxxx" \
+       ngts_scope="tsg_id:1234567890" \
+       zone="my-issuing-template-alias"
+   ```
+
+   Alternatively, supply a pre-issued bearer token instead of the service account:
+
+   ```bash
+   vault write venafi-pki/venafi/ngts \
+       url="https://api.strata.paloaltonetworks.com/ngts" \
+       ngts_access_token="eyJhbGciOi..." \
+       zone="my-issuing-template-alias"
+   ```
+
+   Expected output:
+   ```
+   Success! Data written to: venafi-pki/venafi/ngts
+   ```
+
+   :pushpin: **NOTE**: `ngts_token_url` is the credential sink (the service-account
+   `ngts_client_id`/`ngts_client_secret` are sent there via HTTP Basic auth). The plugin
+   therefore (a) upgrades an `http://` token URL to `https://` with a warning, and
+   (b) **rejects** a token URL whose host is outside `*.paloaltonetworks.com` — a fail-closed
+   posture (stricter than the Go SDK and the Python SDK, which only warn). `url` is optional
+   for NGTS (the SDK defaults to the Strata production host) but recommended for clarity.
+   NGTS certificates can be issued, signed, read, and **revoked** (revocation uses the
+   certificate thumbprint computed locally from the stored certificate, so it requires the
+   role to store the certificate — i.e. not `no_store=true`).
+
 9. Lastly, configure a [role](https://www.vaultproject.io/api-docs/secret/pki#create-update-role)
    that maps a name in Vault to a Venafi secret for enrollment. To see other available
    options for the role after it is created, use `vault path-help venafi-pki/roles/:name`.

--- a/plugin/pki/backend_ngts_test.go
+++ b/plugin/pki/backend_ngts_test.go
@@ -1,0 +1,118 @@
+//go:build ngts
+// +build ngts
+
+package pki
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+
+	"github.com/Venafi/vault-pki-backend-venafi/plugin/util"
+)
+
+// These tests exercise NGTS (Strata Cloud Manager) end-to-end and require a live tenant plus
+// the NGTS_* environment variables (see docs/vault-pki-backend-venafi/NGTS Vault PKI Backend -
+// Issuance Test Procedure.md). They are build-tagged `ngts` and do not run in normal CI — the
+// same model as the TPP/VaaS suites. Run with: make test_ngts
+//
+// Both auth variants are covered: service account (venafiConfigNGTS) and a pre-issued bearer
+// token (venafiConfigNGTSToken).
+
+var ngtsConfigVariants = []venafiConfigString{venafiConfigNGTS, venafiConfigNGTSToken}
+
+func TestNGTSissueReadRevoke(t *testing.T) {
+	for _, cfg := range ngtsConfigVariants {
+		cfg := cfg
+		t.Run(string(cfg), func(t *testing.T) {
+			integrationTestEnv, err := NewIntegrationTestEnv()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			data := testData{
+				cn:        randSeq(9) + ".venafi.example.com",
+				storeBy:   "serial",
+				storePkey: true,
+			}
+			integrationTestEnv.writeVenafiToBackend(t, cfg)
+			integrationTestEnv.writeRoleToBackendWithData(t, cfg, data)
+
+			t.Run("issue", func(t *testing.T) {
+				integrationTestEnv.IssueCertificateAndSaveSerial(t, data, cfg)
+			})
+			t.Run("read", func(t *testing.T) {
+				ngtsReadCertificate(t, integrationTestEnv, util.NormalizeSerial(integrationTestEnv.CertificateSerial))
+			})
+			t.Run("revoke", func(t *testing.T) {
+				// NGTS revokes by locally-computed thumbprint of the stored cert (no SearchCertificates).
+				ngtsRevokeCertificate(t, integrationTestEnv, util.NormalizeSerial(integrationTestEnv.CertificateSerial))
+			})
+		})
+	}
+}
+
+func TestNGTSsign(t *testing.T) {
+	for _, cfg := range ngtsConfigVariants {
+		cfg := cfg
+		t.Run(string(cfg), func(t *testing.T) {
+			integrationTestEnv, err := NewIntegrationTestEnv()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			data := testData{cn: randSeq(9) + ".venafi.example.com", signCSR: true}
+			integrationTestEnv.writeVenafiToBackend(t, cfg)
+			integrationTestEnv.writeRoleToBackendWithData(t, cfg, data)
+			integrationTestEnv.SignCertificate(t, data, cfg)
+		})
+	}
+}
+
+// ngtsRevokeCertificate asserts the revoke path is correctly wired for NGTS. Unlike the shared
+// RevokeCertificate helper (which only checks the Go error), this inspects the logical response:
+//   - success                          → revoke worked (CA supports revocation);
+//   - "...not supported for CA type..." → the CIT's CA (e.g. the built-in CA on some dev tenants)
+//     doesn't support revocation, but the path is still proven correct (thumbprint computed,
+//     API called, no panic / no "thumbprint required"). Accepted.
+//   - anything else (panic, "thumbprint is required", DN errors) → the wiring regressed → fail.
+func ngtsRevokeCertificate(t *testing.T, e *testEnv, certId string) {
+	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "revoke/" + e.RoleName,
+		Storage:   e.Storage,
+		Data:      map[string]interface{}{"certificate_uid": certId},
+	})
+	if err != nil {
+		t.Fatalf("revoke returned a Go error (expected a clean logical response): %v", err)
+	}
+	if resp != nil && resp.IsError() {
+		msg := resp.Error().Error()
+		if strings.Contains(msg, "not supported for CA type") {
+			t.Logf("revoke not supported by this CIT's CA (expected on built-in-CA tenants); "+
+				"path is correctly wired: %s", msg)
+			return
+		}
+		t.Fatalf("revoke failed unexpectedly: %s", msg)
+	}
+}
+
+// ngtsReadCertificate verifies the issued certificate can be read back. It intentionally does
+// not require private_key in the response — the certificate read path no longer returns it.
+func ngtsReadCertificate(t *testing.T, e *testEnv, certId string) {
+	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "cert/" + certId,
+		Storage:   e.Storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.IsError() {
+		t.Fatalf("failed to read NGTS certificate: %#v", resp)
+	}
+	if resp.Data["certificate"] == nil || resp.Data["certificate"] == "" {
+		t.Fatalf("expected a certificate in read data, got: %#v", resp.Data)
+	}
+}

--- a/plugin/pki/env_test.go
+++ b/plugin/pki/env_test.go
@@ -64,6 +64,8 @@ const (
 	venafiConfigCloud                       venafiConfigString = "Cloud"
 	venafiConfigCloudPredefined             venafiConfigString = "CloudPredefined"
 	venafiConfigCloudRestricted             venafiConfigString = "CloudRestricted"
+	venafiConfigNGTS                        venafiConfigString = "NGTS"
+	venafiConfigNGTSToken                   venafiConfigString = "NGTSToken" // #nosec G101
 	venafiConfigToken                       venafiConfigString = "TppToken"
 	venafiConfigTokenPredefined             venafiConfigString = "TppTokenPredefined"  // #nosec G101
 	venafiConfigTokenWithRefresh            venafiConfigString = "TppTokenWithRefresh" // #nosec G101
@@ -123,6 +125,23 @@ var venafiTestCloudConfig = map[string]interface{}{
 var venafiTestCloudConfigPredefined = map[string]interface{}{
 	"apikey": "xxxx-xxxxx-xxxxxx-xxxxxx",
 	"zone":   "xxxxx-xxxxx-xxxxxx-xxxxxx-xxxx",
+}
+
+// NGTS (Strata Cloud Manager) — service-account auth (4-tuple).
+var venafiTestNGTSConfig = map[string]interface{}{
+	"url":                os.Getenv("NGTS_URL"),
+	"zone":               os.Getenv("NGTS_ZONE"),
+	"ngts_token_url":     os.Getenv("NGTS_TOKEN_URL"),
+	"ngts_client_id":     os.Getenv("NGTS_CLIENT_ID"),
+	"ngts_client_secret": os.Getenv("NGTS_CLIENT_SECRET"),
+	"ngts_scope":         os.Getenv("NGTS_SCOPE"),
+}
+
+// NGTS (Strata Cloud Manager) — pre-issued access-token auth.
+var venafiTestNGTSTokenConfig = map[string]interface{}{
+	"url":               os.Getenv("NGTS_URL"),
+	"zone":              os.Getenv("NGTS_ZONE"),
+	"ngts_access_token": os.Getenv("NGTS_ACCESS_TOKEN"),
 }
 
 var venafiTestCloudConfigRestricted = map[string]interface{}{
@@ -1292,6 +1311,10 @@ func makeConfig(configString venafiConfigString) (roleData map[string]interface{
 		roleData = venafiTestCloudConfigPredefined
 	case venafiConfigCloudRestricted:
 		roleData = venafiTestCloudConfigRestricted
+	case venafiConfigNGTS:
+		roleData = venafiTestNGTSConfig
+	case venafiConfigNGTSToken:
+		roleData = venafiTestNGTSTokenConfig
 	case venafiConfigToken:
 		roleData = venafiTestTokenConfig
 	case venafiConfigTokenPredefined:

--- a/plugin/pki/path_venafi_cert_revoke.go
+++ b/plugin/pki/path_venafi_cert_revoke.go
@@ -183,7 +183,12 @@ func isCertificateStored(ctx context.Context, req *logical.Request, id string, r
 func getRevocationRequest(b *backend, c *endpoint.Connector, ctx context.Context, req *logical.Request, zone string, certID string, role *roleEntry) (*certificate.RevocationRequest, error) {
 	revReq := certificate.RevocationRequest{}
 
-	if (*c).GetType() == endpoint.ConnectorTypeCloud {
+	// Cloud/VaaS and NGTS (Strata Cloud Manager) revoke by certificate thumbprint
+	// (they ignore CertificateDN, and NGTS's SearchCertificates panics). The
+	// thumbprint is computed locally from the stored certificate, so no server
+	// search is needed for either backend.
+	connectorType := (*c).GetType()
+	if connectorType == endpoint.ConnectorTypeCloud || connectorType == endpoint.ConnectorTypeNGTS {
 		thumbprint, err := getThumbprintFromStorage(b, ctx, req, certID)
 		if err != nil {
 			return nil, err

--- a/plugin/pki/path_venafi_cert_revoke_test.go
+++ b/plugin/pki/path_venafi_cert_revoke_test.go
@@ -160,6 +160,52 @@ func TestGetRevocationRequestCloudUsesStoredCertificateThumbprint(t *testing.T) 
 	}
 }
 
+func TestGetRevocationRequestNGTSUsesStoredCertificateThumbprint(t *testing.T) {
+	ctx := context.Background()
+	storage := &logical.InmemStorage{}
+	conf := logical.TestBackendConfig()
+	conf.StorageView = storage
+	b := Backend(conf)
+	if err := b.Setup(ctx, conf); err != nil {
+		t.Fatal(err)
+	}
+
+	certPEM, rawCert := testCertificatePEM(t)
+	entry, err := logical.StorageEntryJSON("certs/aa-bb-cc", VenafiCert{
+		Certificate:  certPEM,
+		SerialNumber: "aa:bb:cc",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.Put(ctx, entry); err != nil {
+		t.Fatal(err)
+	}
+
+	connector := &revokeTestConnector{connectorType: endpoint.ConnectorTypeNGTS}
+	var cl endpoint.Connector = connector
+	req := &logical.Request{Storage: storage}
+	role := &roleEntry{StoreBy: util.StoreBySerialString}
+
+	revReq, err := getRevocationRequest(b, &cl, ctx, req, "", "aa-bb-cc", role)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if connector.searchCalled {
+		t.Fatal("NGTS revocation should not call SearchCertificates")
+	}
+	if revReq.CertificateDN != "" {
+		t.Fatalf("expected no CertificateDN for NGTS revocation, got %q", revReq.CertificateDN)
+	}
+
+	thumbprint := sha1.Sum(rawCert)
+	expectedThumbprint := strings.ToUpper(hex.EncodeToString(thumbprint[:]))
+	if revReq.Thumbprint != expectedThumbprint {
+		t.Fatalf("expected thumbprint %q, got %q", expectedThumbprint, revReq.Thumbprint)
+	}
+}
+
 func testCertificatePEM(t *testing.T) (string, []byte) {
 	t.Helper()
 

--- a/plugin/pki/path_venafi_secrets.go
+++ b/plugin/pki/path_venafi_secrets.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -12,6 +15,10 @@ import (
 
 	"github.com/Venafi/vault-pki-backend-venafi/plugin/util"
 )
+
+// ngtsScopeRegex anchors the NGTS scope format (tsg_id:<10 digits>), stricter than the
+// Go SDK's unanchored check — matching the vcert-python behavior.
+var ngtsScopeRegex = regexp.MustCompile(util.NgtsScopePattern)
 
 func pathCredentialsList(b *backend) *framework.Path {
 	return &framework.Path{
@@ -106,6 +113,26 @@ Example: trust_bundle_file="/path-to/bundle.pem""`,
 				Description: `Use to specify the application that will be using the token.`,
 				Default:     `hashicorp-vault-by-venafi`,
 			},
+			"ngts_token_url": {
+				Type:        framework.TypeString,
+				Description: `Strata Cloud Manager (NGTS) OAuth2 token endpoint for service-account authentication. Must be an https:// URL within ` + util.NgtsTrustedTokenHostSuffix,
+			},
+			"ngts_client_id": {
+				Type:        framework.TypeString,
+				Description: `Strata Cloud Manager (NGTS) service-account client id.`,
+			},
+			"ngts_client_secret": {
+				Type:        framework.TypeString,
+				Description: `Strata Cloud Manager (NGTS) service-account client secret.`,
+			},
+			"ngts_scope": {
+				Type:        framework.TypeString,
+				Description: `Strata Cloud Manager (NGTS) OAuth2 scope, in the form tsg_id:<10-digit TSG ID>.`,
+			},
+			"ngts_access_token": {
+				Type:        framework.TypeString,
+				Description: `Pre-issued Strata Cloud Manager (NGTS) bearer token; alternative to the ngts_client_id/ngts_client_secret service account.`,
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
@@ -190,21 +217,26 @@ func (b *backend) pathVenafiSecretCreate(ctx context.Context, req *logical.Reque
 	}
 
 	entry := &venafiSecretEntry{
-		URL:             url,
-		Zone:            data.Get("zone").(string),
-		TppURL:          tppUrl,
-		TppUser:         data.Get("tpp_user").(string),
-		TppPassword:     data.Get("tpp_password").(string),
-		AccessToken:     data.Get("access_token").(string),
-		RefreshToken:    data.Get("refresh_token").(string),
-		RefreshToken2:   data.Get("refresh_token_2").(string),
-		RefreshInterval: time.Duration(data.Get("refresh_interval").(int)) * time.Second,
-		NextRefresh:     time.Now(),
-		CloudURL:        cloudUrl,
-		Apikey:          data.Get("apikey").(string),
-		TrustBundleFile: data.Get("trust_bundle_file").(string),
-		Fakemode:        data.Get("fakemode").(bool),
-		ClientId:        data.Get("client_id").(string),
+		URL:              url,
+		Zone:             data.Get("zone").(string),
+		TppURL:           tppUrl,
+		TppUser:          data.Get("tpp_user").(string),
+		TppPassword:      data.Get("tpp_password").(string),
+		AccessToken:      data.Get("access_token").(string),
+		RefreshToken:     data.Get("refresh_token").(string),
+		RefreshToken2:    data.Get("refresh_token_2").(string),
+		RefreshInterval:  time.Duration(data.Get("refresh_interval").(int)) * time.Second,
+		NextRefresh:      time.Now(),
+		CloudURL:         cloudUrl,
+		Apikey:           data.Get("apikey").(string),
+		TrustBundleFile:  data.Get("trust_bundle_file").(string),
+		Fakemode:         data.Get("fakemode").(bool),
+		ClientId:         data.Get("client_id").(string),
+		NgtsTokenURL:     data.Get("ngts_token_url").(string),
+		NgtsClientId:     data.Get("ngts_client_id").(string),
+		NgtsClientSecret: data.Get("ngts_client_secret").(string),
+		NgtsScope:        data.Get("ngts_scope").(string),
+		NgtsAccessToken:  data.Get("ngts_access_token").(string),
 	}
 
 	b.Logger().Info(fmt.Sprintf("Validating data for CyberArk secret %s", name))
@@ -212,6 +244,20 @@ func (b *backend) pathVenafiSecretCreate(ctx context.Context, req *logical.Reque
 	if err != nil {
 		b.Logger().Error(fmt.Sprintf("Error with CyberArk secret data: %s", err.Error()))
 		return logical.ErrorResponse(err.Error()), nil
+	}
+
+	// Harden the NGTS token URL (credential sink) at create time, so the stored value is
+	// already https:// and within the trusted Palo Alto domain and is reused on every issue.
+	// Only applies to service-account auth (skipped for a pre-issued ngts_access_token).
+	var ngtsWarnings []string
+	if entry.isNgts() && entry.NgtsAccessToken == "" {
+		normalized, warns, nErr := normalizeNgtsTokenURL(entry.NgtsTokenURL)
+		if nErr != nil {
+			b.Logger().Error(fmt.Sprintf("Error with NGTS token URL: %s", nErr.Error()))
+			return logical.ErrorResponse(nErr.Error()), nil
+		}
+		entry.NgtsTokenURL = normalized
+		ngtsWarnings = warns
 	}
 	if entry.RefreshToken != "" && !entry.Fakemode {
 		b.Logger().Info("Refresh tokens are provided. Setting up data")
@@ -275,7 +321,7 @@ func (b *backend) pathVenafiSecretCreate(ctx context.Context, req *logical.Reque
 
 	var logResp *logical.Response
 
-	warnings := getWarnings(entry, name)
+	warnings := append(ngtsWarnings, getWarnings(entry, name)...)
 
 	if cap(warnings) > 0 {
 		logResp = &logical.Response{
@@ -310,19 +356,34 @@ func (b *backend) getVenafiSecret(ctx context.Context, s logical.Storage, name s
 }
 
 func validateVenafiSecretEntry(entry *venafiSecretEntry) error {
-	if !entry.Fakemode && entry.Apikey == "" && (entry.TppUser == "" || entry.TppPassword == "") && entry.RefreshToken == "" && entry.AccessToken == "" {
+	if !entry.Fakemode && entry.Apikey == "" && (entry.TppUser == "" || entry.TppPassword == "") && entry.RefreshToken == "" && entry.AccessToken == "" && !entry.isNgts() {
 		return errors.New(util.ErrorTextInvalidMode)
 	}
 
 	//Only validate other fields if mode is not fakemode
 	if !entry.Fakemode {
-		//When api key is null, that means
-		if entry.URL == "" && entry.Apikey == "" {
+		// NGTS may omit url (the SDK default host is production-correct at v5.13.7), so the
+		// url-required check is skipped for NGTS — but zone is still required (validated below).
+		if entry.URL == "" && entry.Apikey == "" && !entry.isNgts() {
 			return errors.New(util.ErrorTextURLEmpty)
 		}
 
 		if entry.Zone == "" {
 			return errors.New(util.ErrorTextZoneEmpty)
+		}
+
+		// NGTS must not be combined with any other backend's credentials.
+		if entry.isNgts() {
+			if entry.TppUser != "" || entry.TppPassword != "" {
+				return errors.New(util.ErrorTextMixedNgtsAndTPP)
+			}
+			if entry.AccessToken != "" || entry.RefreshToken != "" {
+				return errors.New(util.ErrorTextMixedNgtsAndToken)
+			}
+			if entry.Apikey != "" {
+				return errors.New(util.ErrorTextMixedNgtsAndCloud)
+			}
+			return validateNgtsSecretEntry(entry)
 		}
 
 		if entry.TppUser != "" && entry.Apikey != "" {
@@ -342,6 +403,61 @@ func validateVenafiSecretEntry(entry *venafiSecretEntry) error {
 		}
 	}
 	return nil
+}
+
+// validateNgtsSecretEntry validates an NGTS secret: either a complete service-account
+// 4-tuple (client_id + client_secret + token_url + scope) or a pre-issued access token.
+// Token-URL host/scheme hardening happens separately in normalizeNgtsTokenURL at create time.
+func validateNgtsSecretEntry(entry *venafiSecretEntry) error {
+	if entry.NgtsAccessToken != "" {
+		return nil
+	}
+
+	if entry.NgtsClientId == "" || entry.NgtsClientSecret == "" {
+		return errors.New(util.ErrorTextNgtsCredsIncomplete)
+	}
+	if entry.NgtsTokenURL == "" {
+		return errors.New(util.ErrorTextNgtsTokenURLEmpty)
+	}
+	if !ngtsScopeRegex.MatchString(entry.NgtsScope) {
+		return errors.New(util.ErrorTextNgtsScopeInvalid)
+	}
+	return nil
+}
+
+// normalizeNgtsTokenURL hardens the NGTS token endpoint, which receives the service-account
+// client_id/client_secret via HTTP Basic auth (the Go SDK applies no scheme/host checks):
+//  1. coerce http:// -> https:// (with a warning), default a scheme-less value to https://;
+//  2. reject (fail-closed) any host outside the trusted Palo Alto domain.
+//
+// Empty input is left to validateNgtsSecretEntry, which requires a token URL in service-account mode.
+func normalizeNgtsTokenURL(raw string) (string, []string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", nil, nil
+	}
+
+	var warnings []string
+	lower := strings.ToLower(trimmed)
+	switch {
+	case strings.HasPrefix(lower, "http://"):
+		trimmed = "https://" + trimmed[len("http://"):]
+		warnings = append(warnings, util.WarningNgtsTokenURLHTTPUpgraded)
+	case !strings.HasPrefix(lower, "https://"):
+		trimmed = "https://" + trimmed
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", warnings, fmt.Errorf(util.ErrorTextNgtsTokenURLInvalid, err.Error())
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" || !strings.HasSuffix(host, util.NgtsTrustedTokenHostSuffix) {
+		return "", warnings, fmt.Errorf(util.ErrorTextNgtsTokenURLUntrustedHost, host, util.NgtsTrustedTokenHostSuffix)
+	}
+
+	return trimmed, warnings, nil
 }
 
 func getWarnings(entry *venafiSecretEntry, name string) []string {
@@ -383,6 +499,21 @@ type venafiSecretEntry struct {
 	TrustBundleFile string        `json:"trust_bundle_file"`
 	Fakemode        bool          `json:"fakemode"`
 	ClientId        string        `json:"client_id"`
+
+	// NGTS (Strata Cloud Manager) service-account / pre-issued-token fields.
+	NgtsTokenURL     string `json:"ngts_token_url"`
+	NgtsClientId     string `json:"ngts_client_id"`
+	NgtsClientSecret string `json:"ngts_client_secret"`
+	NgtsScope        string `json:"ngts_scope"`
+	NgtsAccessToken  string `json:"ngts_access_token"`
+}
+
+// isNgts reports whether any NGTS field is set, i.e. the secret is meant for the
+// Strata Cloud Manager (NGTS) backend. Selection is by field presence, mirroring the
+// implicit backend selection used for TPP/Cloud.
+func (p *venafiSecretEntry) isNgts() bool {
+	return p.NgtsTokenURL != "" || p.NgtsClientId != "" || p.NgtsClientSecret != "" ||
+		p.NgtsScope != "" || p.NgtsAccessToken != ""
 }
 
 func (p *venafiSecretEntry) ToResponseData() map[string]interface{} {
@@ -403,6 +534,13 @@ func (p *venafiSecretEntry) ToResponseData() map[string]interface{} {
 		"trust_bundle_file": p.TrustBundleFile,
 		"fakemode":          p.Fakemode,
 		"client_id":         p.ClientId,
+
+		//ngts_client_secret and ngts_access_token are sensitive and stay masked
+		"ngts_token_url":     p.NgtsTokenURL,
+		"ngts_client_id":     p.NgtsClientId,
+		"ngts_client_secret": p.getStringMask(),
+		"ngts_scope":         p.NgtsScope,
+		"ngts_access_token":  p.getStringMask(),
 	}
 	return responseData
 }

--- a/plugin/pki/path_venafi_secrets_test.go
+++ b/plugin/pki/path_venafi_secrets_test.go
@@ -1,7 +1,11 @@
 package pki
 
 import (
+	"context"
 	"testing"
+
+	"github.com/Venafi/vcert/v5/pkg/endpoint"
+	"github.com/hashicorp/vault/sdk/logical"
 
 	"github.com/Venafi/vault-pki-backend-venafi/plugin/util"
 )
@@ -87,5 +91,229 @@ func TestVenafiSecretValidate(t *testing.T) {
 	}
 	if err.Error() != util.ErrorTextMixedTokenAndCloud {
 		t.Fatalf("Expecting error %s but got %s", util.ErrorTextMixedTokenAndCloud, err)
+	}
+}
+
+func TestNgtsSecretValidate(t *testing.T) {
+	const (
+		validTokenURL = "https://auth.apps.paloaltonetworks.com/oauth2/access_token"
+		validScope    = "tsg_id:1234567890"
+	)
+
+	// Valid service-account secret (url omitted on purpose — allowed for NGTS at v5.13.7).
+	entry := &venafiSecretEntry{
+		Zone:             "my-cit",
+		NgtsClientId:     "svc@1234567890.iam.panserviceaccount.com",
+		NgtsClientSecret: "secret",
+		NgtsTokenURL:     validTokenURL,
+		NgtsScope:        validScope,
+	}
+	if err := validateVenafiSecretEntry(entry); err != nil {
+		t.Fatalf("expected valid NGTS service-account secret, got: %s", err)
+	}
+
+	// Valid pre-issued access-token secret (no token_url/scope required).
+	entry = &venafiSecretEntry{Zone: "my-cit", NgtsAccessToken: "bearer-xyz"}
+	if err := validateVenafiSecretEntry(entry); err != nil {
+		t.Fatalf("expected valid NGTS access-token secret, got: %s", err)
+	}
+
+	cases := []struct {
+		name     string
+		entry    *venafiSecretEntry
+		expected string
+	}{
+		{
+			name:     "missing zone",
+			entry:    &venafiSecretEntry{NgtsAccessToken: "bearer-xyz"},
+			expected: util.ErrorTextZoneEmpty,
+		},
+		{
+			name:     "incomplete creds (no client_secret)",
+			entry:    &venafiSecretEntry{Zone: "my-cit", NgtsClientId: "svc", NgtsTokenURL: validTokenURL, NgtsScope: validScope},
+			expected: util.ErrorTextNgtsCredsIncomplete,
+		},
+		{
+			name:     "missing token_url in service-account mode",
+			entry:    &venafiSecretEntry{Zone: "my-cit", NgtsClientId: "svc", NgtsClientSecret: "secret", NgtsScope: validScope},
+			expected: util.ErrorTextNgtsTokenURLEmpty,
+		},
+		{
+			name:     "invalid scope",
+			entry:    &venafiSecretEntry{Zone: "my-cit", NgtsClientId: "svc", NgtsClientSecret: "secret", NgtsTokenURL: validTokenURL, NgtsScope: "tsg_id:123"},
+			expected: util.ErrorTextNgtsScopeInvalid,
+		},
+		{
+			name:     "mixed with cloud apikey",
+			entry:    &venafiSecretEntry{Zone: "my-cit", NgtsAccessToken: "bearer-xyz", Apikey: "k"},
+			expected: util.ErrorTextMixedNgtsAndCloud,
+		},
+		{
+			name:     "mixed with TPP token",
+			entry:    &venafiSecretEntry{Zone: "my-cit", NgtsAccessToken: "bearer-xyz", AccessToken: "tok"},
+			expected: util.ErrorTextMixedNgtsAndToken,
+		},
+		{
+			name:     "mixed with TPP user/password",
+			entry:    &venafiSecretEntry{Zone: "my-cit", NgtsAccessToken: "bearer-xyz", TppUser: "u", TppPassword: "p"},
+			expected: util.ErrorTextMixedNgtsAndTPP,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateVenafiSecretEntry(tc.entry)
+			if err == nil {
+				t.Fatalf("expected error %q, got nil", tc.expected)
+			}
+			if err.Error() != tc.expected {
+				t.Fatalf("expected error %q, got %q", tc.expected, err.Error())
+			}
+		})
+	}
+}
+
+func TestNormalizeNgtsTokenURL(t *testing.T) {
+	const trustedHTTPS = "https://auth.apps.paloaltonetworks.com/oauth2/access_token"
+
+	// http:// is upgraded to https:// with a warning.
+	got, warns, err := normalizeNgtsTokenURL("http://auth.apps.paloaltonetworks.com/oauth2/access_token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != trustedHTTPS {
+		t.Fatalf("expected %q, got %q", trustedHTTPS, got)
+	}
+	if len(warns) != 1 || warns[0] != util.WarningNgtsTokenURLHTTPUpgraded {
+		t.Fatalf("expected http-upgrade warning, got %v", warns)
+	}
+
+	// A scheme-less value defaults to https:// with no warning.
+	got, warns, err = normalizeNgtsTokenURL("auth.apps.paloaltonetworks.com/oauth2/access_token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != trustedHTTPS {
+		t.Fatalf("expected %q, got %q", trustedHTTPS, got)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("expected no warning, got %v", warns)
+	}
+
+	// A trusted https:// host passes through unchanged.
+	got, _, err = normalizeNgtsTokenURL(trustedHTTPS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != trustedHTTPS {
+		t.Fatalf("expected %q, got %q", trustedHTTPS, got)
+	}
+
+	// Untrusted hosts are rejected (fail-closed), even when reached via http://.
+	if _, _, err = normalizeNgtsTokenURL("https://evil.example.com/oauth2/access_token"); err == nil {
+		t.Fatal("expected untrusted-host rejection for https evil host")
+	}
+	if _, _, err = normalizeNgtsTokenURL("http://evil.example.com/token"); err == nil {
+		t.Fatal("expected untrusted-host rejection for http evil host")
+	}
+
+	// Look-alike domain must not be accepted by the suffix check.
+	if _, _, err = normalizeNgtsTokenURL("https://auth.evilpaloaltonetworks.com/token"); err == nil {
+		t.Fatal("expected rejection of look-alike domain")
+	}
+
+	// Empty input is passed through (emptiness is enforced by validation).
+	got, warns, err = normalizeNgtsTokenURL("")
+	if err != nil || got != "" || warns != nil {
+		t.Fatalf("expected empty passthrough, got %q %v %v", got, warns, err)
+	}
+}
+
+func TestGetConfigNGTSServiceAccount(t *testing.T) {
+	ctx := context.Background()
+	storage := &logical.InmemStorage{}
+	conf := logical.TestBackendConfig()
+	conf.StorageView = storage
+	b := Backend(conf)
+	if err := b.Setup(ctx, conf); err != nil {
+		t.Fatal(err)
+	}
+
+	secret := &venafiSecretEntry{
+		URL:              "https://api.strata.paloaltonetworks.com/ngts",
+		Zone:             "my-cit",
+		NgtsClientId:     "svc@1234567890.iam.panserviceaccount.com",
+		NgtsClientSecret: "secret",
+		NgtsTokenURL:     "https://auth.apps.paloaltonetworks.com/oauth2/access_token",
+		NgtsScope:        "tsg_id:1234567890",
+	}
+	entry, err := logical.StorageEntryJSON(util.CredentialsRootPath+"ngts", secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.Put(ctx, entry); err != nil {
+		t.Fatal(err)
+	}
+
+	role := &roleEntry{VenafiSecret: "ngts"}
+	cfg, err := b.getConfig(ctx, &logical.Request{Storage: storage}, role, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ConnectorType != endpoint.ConnectorTypeNGTS {
+		t.Fatalf("expected NGTS connector type, got %v", cfg.ConnectorType)
+	}
+	if cfg.BaseUrl != secret.URL {
+		t.Fatalf("expected BaseUrl %q, got %q", secret.URL, cfg.BaseUrl)
+	}
+	if cfg.Credentials == nil {
+		t.Fatal("expected credentials to be set")
+	}
+	if cfg.Credentials.ClientId != secret.NgtsClientId ||
+		cfg.Credentials.ClientSecret != secret.NgtsClientSecret ||
+		cfg.Credentials.TokenURL != secret.NgtsTokenURL ||
+		cfg.Credentials.Scope != secret.NgtsScope {
+		t.Fatalf("NGTS service-account credentials not forwarded correctly: %#v", cfg.Credentials)
+	}
+	if cfg.Credentials.AccessToken != "" {
+		t.Fatalf("did not expect an access token in service-account mode, got %q", cfg.Credentials.AccessToken)
+	}
+}
+
+func TestGetConfigNGTSAccessToken(t *testing.T) {
+	ctx := context.Background()
+	storage := &logical.InmemStorage{}
+	conf := logical.TestBackendConfig()
+	conf.StorageView = storage
+	b := Backend(conf)
+	if err := b.Setup(ctx, conf); err != nil {
+		t.Fatal(err)
+	}
+
+	secret := &venafiSecretEntry{
+		Zone:            "my-cit",
+		NgtsAccessToken: "bearer-xyz",
+	}
+	entry, err := logical.StorageEntryJSON(util.CredentialsRootPath+"ngts-token", secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.Put(ctx, entry); err != nil {
+		t.Fatal(err)
+	}
+
+	role := &roleEntry{VenafiSecret: "ngts-token"}
+	cfg, err := b.getConfig(ctx, &logical.Request{Storage: storage}, role, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ConnectorType != endpoint.ConnectorTypeNGTS {
+		t.Fatalf("expected NGTS connector type, got %v", cfg.ConnectorType)
+	}
+	if cfg.Credentials == nil || cfg.Credentials.AccessToken != secret.NgtsAccessToken {
+		t.Fatalf("expected access token %q to be forwarded, got %#v", secret.NgtsAccessToken, cfg.Credentials)
+	}
+	if cfg.Credentials.ClientId != "" || cfg.Credentials.ClientSecret != "" {
+		t.Fatalf("did not expect service-account fields in access-token mode: %#v", cfg.Credentials)
 	}
 }

--- a/plugin/pki/vcert.go
+++ b/plugin/pki/vcert.go
@@ -96,6 +96,24 @@ func (b *backend) getConfig(ctx context.Context, req *logical.Request, role *rol
 			LogVerbose:    true,
 		}
 
+	} else if venafiSecret.isNgts() {
+		b.Logger().Debug("Using Strata Cloud Manager (NGTS) to issue certificate")
+		cfg.ConnectorType = endpoint.ConnectorTypeNGTS
+		// cfg.BaseUrl is already set from venafiSecret.URL; an empty URL falls back to the
+		// SDK's production default (api.strata.paloaltonetworks.com/ngts at v5.13.7).
+		if venafiSecret.NgtsAccessToken != "" {
+			cfg.Credentials = &endpoint.Authentication{
+				AccessToken: venafiSecret.NgtsAccessToken,
+			}
+		} else {
+			cfg.Credentials = &endpoint.Authentication{
+				ClientId:     venafiSecret.NgtsClientId,
+				ClientSecret: venafiSecret.NgtsClientSecret,
+				TokenURL:     venafiSecret.NgtsTokenURL,
+				Scope:        venafiSecret.NgtsScope,
+			}
+		}
+
 	} else if venafiSecret.URL != "" && venafiSecret.TppUser != "" && venafiSecret.TppPassword != "" {
 		b.Logger().Debug(fmt.Sprintf("Using Certificate Manager, Self-Hosted with URL %s to issue certificate", venafiSecret.URL))
 		cfg.ConnectorType = endpoint.ConnectorTypeTPP

--- a/plugin/util/constants.go
+++ b/plugin/util/constants.go
@@ -7,6 +7,7 @@ const (
 	tokenMode                                    = `Certificate Manager, Self-Hosted Token (access_token, refresh_token)` // #nosec G101
 	tppMode                                      = `Certificate Manager, Self-Hosted Credentials (tpp_user, tpp_password)`
 	cloudMode                                    = `Cloud API Key (apikey)`
+	ngtsMode                                     = `Strata Cloud Manager (NGTS) service account (ngts_client_id, ngts_client_secret) or pre-issued ngts_access_token` // #nosec G101
 	StoreByCNString                              = "cn"
 	StoreByHASHstring                            = "hash"
 	StoreBySerialString                          = "serial"
@@ -18,9 +19,21 @@ const (
 	ErrorTextVenafiSecretEmpty                   = `"venafi_secret" argument is required`
 	ErrorTextURLEmpty                            = `"url" argument is required`
 	ErrorTextZoneEmpty                           = `"zone" argument is required`
-	ErrorTextInvalidMode                         = "invalid mode: fakemode or apikey or Certificate Manager, Self-Hosted credentials or Certificate Manager, Self-Hosted access token required"
+	ErrorTextInvalidMode                         = "invalid mode: fakemode or apikey or Certificate Manager, Self-Hosted credentials or Certificate Manager, Self-Hosted access token or NGTS service account required"
 	ErrorTextNeed2RefreshTokens                  = "secrets engine requires 2 refresh tokens for no impact token refresh"
 	errorMultiModeMessage                        = `can't specify both: %s and %s modes in the same CyberArk secret`
+
+	// NGTS (Strata Cloud Manager) — service-account auth is a credential sink; see
+	// the NGTS implementation plan in docs/vault-pki-backend-venafi/.
+	NgtsTrustedTokenHostSuffix = ".paloaltonetworks.com" // token URL must be within the trusted Palo Alto domain
+	NgtsScopePattern           = `^tsg_id:[0-9]{10}$`    // anchored (stricter than the Go SDK's unanchored check)
+
+	ErrorTextNgtsCredsIncomplete       = "NGTS requires either ngts_client_id, ngts_client_secret, ngts_token_url and ngts_scope, or a pre-issued ngts_access_token"
+	ErrorTextNgtsTokenURLEmpty         = "ngts_token_url is required for NGTS service-account authentication"                                       // #nosec G101
+	ErrorTextNgtsScopeInvalid          = "ngts_scope must be in the form tsg_id:<10-digit TSG ID>"                                                  // #nosec G101
+	ErrorTextNgtsTokenURLInvalid       = "ngts_token_url is not a valid URL: %s"                                                                    // #nosec G101
+	ErrorTextNgtsTokenURLUntrustedHost = "ngts_token_url host %q is not within the trusted domain %q; refusing to send service-account credentials" // #nosec G101
+	WarningNgtsTokenURLHTTPUpgraded    = "ngts_token_url used http://; upgraded to https:// to protect service-account credentials"                 // #nosec G101
 )
 
 const (
@@ -32,4 +45,7 @@ var (
 	ErrorTextMixedTPPAndToken   = fmt.Sprintf(errorMultiModeMessage, tppMode, tokenMode)
 	ErrorTextMixedTPPAndCloud   = fmt.Sprintf(errorMultiModeMessage, tppMode, cloudMode)
 	ErrorTextMixedTokenAndCloud = fmt.Sprintf(errorMultiModeMessage, tokenMode, cloudMode)
+	ErrorTextMixedNgtsAndTPP    = fmt.Sprintf(errorMultiModeMessage, ngtsMode, tppMode)
+	ErrorTextMixedNgtsAndToken  = fmt.Sprintf(errorMultiModeMessage, ngtsMode, tokenMode)
+	ErrorTextMixedNgtsAndCloud  = fmt.Sprintf(errorMultiModeMessage, ngtsMode, cloudMode)
 )


### PR DESCRIPTION
NGTS becomes a fourth backend (issue/sign/read/revoke), selected by the presence of ngts_* secret fields.

- Bump VCert SDK v5.12.3 -> v5.13.7 (NGTS connector needs >= v5.13.5)
- Secret schema: ngts_* fields + validation (service-account 4-tuple or pre-issued token; anchored tsg_id scope; mixed-mode rejection; masking)
- Harden ngts_token_url credential sink: force https, reject hosts outside *.paloaltonetworks.com (fail-closed)
- getConfig routes NGTS; revoke uses a locally-computed thumbprint (shares the Cloud branch)
- Tests (unit + build-tagged live make test_ngts), README, CHANGELOG